### PR TITLE
fix: l'import pcap échoue avec des espaces ou caractères spéciaux dans le chemin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,10 @@ src-tauri/vendor/**/target/**.exe
 # Tauri
 target
 /target
+
+# Nix
+shell.nix
+
+# Dev tools
+gen_pcap.py
+test.pcap

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,3 +55,6 @@ sysinfo = "0.38.3"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-cli = "2"
 tauri-plugin-global-shortcut = "2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }

--- a/src-tauri/src/commandes/import/mod.rs
+++ b/src-tauri/src/commandes/import/mod.rs
@@ -1,6 +1,8 @@
 use log::{error, info};
 use packet_parser::PacketFlow;
 use pcap::Capture;
+use std::fs::File;
+use std::os::unix::io::IntoRawFd;
 use std::sync::{Arc, Mutex};
 use tauri::{State, ipc::Channel};
 
@@ -13,13 +15,25 @@ use crate::{
     },
 };
 
-fn count_packets_in_pcap(file_path: &str) -> Result<usize, CaptureStateError> {
-    let mut cap = Capture::from_file(file_path).map_err(|e| {
+fn open_capture(file_path: &str) -> Result<Capture<pcap::Offline>, CaptureStateError> {
+    let file = File::open(file_path).map_err(|e| {
         CaptureStateError::Import(PcapImportError::OpenFileError(
             file_path.to_string(),
             e.to_string(),
         ))
     })?;
+    let fd = file.into_raw_fd();
+    // SAFETY: fd est valide et nous en sommes propriétaires
+    unsafe { Capture::from_raw_fd(fd) }.map_err(|e| {
+        CaptureStateError::Import(PcapImportError::OpenFileError(
+            file_path.to_string(),
+            e.to_string(),
+        ))
+    })
+}
+
+fn count_packets_in_pcap(file_path: &str) -> Result<usize, CaptureStateError> {
+    let mut cap = open_capture(file_path)?;
 
     let mut count: usize = 0;
     while cap.next_packet().is_ok() {
@@ -89,12 +103,7 @@ fn handle_pcap_file(
         file_path, total
     );
 
-    let mut cap = Capture::from_file(file_path).map_err(|e| {
-        CaptureStateError::Import(PcapImportError::OpenFileError(
-            file_path.to_string(),
-            e.to_string(),
-        ))
-    })?;
+    let mut cap = open_capture(file_path)?;
 
     let mut packet_count: usize = 0;
 

--- a/src-tauri/src/commandes/import/mod.rs
+++ b/src-tauri/src/commandes/import/mod.rs
@@ -34,7 +34,40 @@ fn open_capture(file_path: &str) -> Result<Capture<pcap::Offline>, CaptureStateE
             ))
         })
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+        // Convertit le chemin en UTF-16 pour l'API Windows
+        let wide: Vec<u16> = OsStr::new(file_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        // Récupère la taille du buffer nécessaire pour le chemin court (8.3)
+        let len = unsafe { GetShortPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+
+        let short_path = if len > 0 {
+            let mut buf = vec![0u16; len as usize];
+            unsafe { GetShortPathNameW(wide.as_ptr(), buf.as_mut_ptr(), len) };
+            // Retire le null-terminator
+            String::from_utf16_lossy(&buf[..len as usize - 1])
+        } else {
+            // Fallback si GetShortPathNameW échoue (ex: short names désactivés)
+            file_path.to_string()
+        };
+
+        Capture::from_file(&short_path).map_err(|e| {
+            CaptureStateError::Import(PcapImportError::OpenFileError(
+                file_path.to_string(),
+                e.to_string(),
+            ))
+        })
+    }
+
+    #[cfg(not(any(unix, windows)))]
     {
         Capture::from_file(file_path).map_err(|e| {
             CaptureStateError::Import(PcapImportError::OpenFileError(

--- a/src-tauri/src/commandes/import/mod.rs
+++ b/src-tauri/src/commandes/import/mod.rs
@@ -2,6 +2,7 @@ use log::{error, info};
 use packet_parser::PacketFlow;
 use pcap::Capture;
 use std::fs::File;
+#[cfg(unix)]
 use std::os::unix::io::IntoRawFd;
 use std::sync::{Arc, Mutex};
 use tauri::{State, ipc::Channel};
@@ -16,20 +17,32 @@ use crate::{
 };
 
 fn open_capture(file_path: &str) -> Result<Capture<pcap::Offline>, CaptureStateError> {
-    let file = File::open(file_path).map_err(|e| {
-        CaptureStateError::Import(PcapImportError::OpenFileError(
-            file_path.to_string(),
-            e.to_string(),
-        ))
-    })?;
-    let fd = file.into_raw_fd();
-    // SAFETY: fd est valide et nous en sommes propriétaires
-    unsafe { Capture::from_raw_fd(fd) }.map_err(|e| {
-        CaptureStateError::Import(PcapImportError::OpenFileError(
-            file_path.to_string(),
-            e.to_string(),
-        ))
-    })
+    #[cfg(unix)]
+    {
+        let file = File::open(file_path).map_err(|e| {
+            CaptureStateError::Import(PcapImportError::OpenFileError(
+                file_path.to_string(),
+                e.to_string(),
+            ))
+        })?;
+        let fd = file.into_raw_fd();
+        // SAFETY: fd est valide et nous en sommes propriétaires. `from_raw_fd` en prend possession.
+        unsafe { Capture::from_raw_fd(fd) }.map_err(|e| {
+            CaptureStateError::Import(PcapImportError::OpenFileError(
+                file_path.to_string(),
+                e.to_string(),
+            ))
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        Capture::from_file(file_path).map_err(|e| {
+            CaptureStateError::Import(PcapImportError::OpenFileError(
+                file_path.to_string(),
+                e.to_string(),
+            ))
+        })
+    }
 }
 
 fn count_packets_in_pcap(file_path: &str) -> Result<usize, CaptureStateError> {


### PR DESCRIPTION
Fixes #88

## Problème

`Capture::from_file` appelle `.to_str()` sur le chemin, qui retourne `None` pour les chemins non-UTF-8. Dans ce cas, `new_raw` passe `NULL` à `pcap_open_offline`, qui lit stdin au lieu du fichier.

Même pour les chemins UTF-8 valides, `pcap_open_offline` (fonction C) peut mal gérer les chemins contenant des espaces ou des caractères spéciaux selon la locale système.

## Correction

Ajout d'une fonction `open_capture` qui :
1. Ouvre le fichier avec `std::fs::File::open` — la gestion native des chemins par Rust fonctionne correctement pour tous les chemins valides (espaces, accents, `#`, `()`, etc.)
2. Passe le descripteur de fichier à `Capture::from_raw_fd` qui utilise `pcap_fopen_offline(FILE*)` au lieu de `pcap_open_offline(path)`, contournant tout problème d'encodage dans libpcap

## Test

Testé avec un fichier nommé `mon capture (été) #2.pcap` — l'import fonctionne correctement.