### PR TITLE
Add official Windows HSM release builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Limites, toutes **explicites** (jamais de dégradation silencieuse) :
 Release assets contain raw binaries and native bundles: DMG on macOS, DEB/RPM
 on Linux and NSIS setup on Windows.
 
+La fabrication manuelle d’une release Windows officielle, signée par le HSM de
+l’entreprise et accompagnée d’une provenance SLSA, est décrite dans le
+[guide opérateur Windows](script/release/WIN_OFFICIEL_BUILDER_HSM_PROV.md).
+
 ## Configuration minimale
 
 - **Systeme 64 bits:** Windows 10/11, Linux x86_64 recent ou macOS recent.

--- a/script/release/WIN_OFFICIEL_BUILDER_HSM_PROV.md
+++ b/script/release/WIN_OFFICIEL_BUILDER_HSM_PROV.md
@@ -1,0 +1,341 @@
+# Build Windows officiel avec HSM et provenance
+
+Cette procédure décrit l’utilisation de
+`script/release/win_officiel_builder_hsm_prov.ps1` sur le poste Windows sécurisé
+de release.
+
+Le script construit uniquement l’installateur NSIS de SONAR, signe les
+exécutables avec le certificat Authenticode de l’entreprise, génère une
+provenance SLSA v1 et la signe avec une seconde clé gérée par Cosign. Il ne
+cherche pas à produire un build reproductible : la preuve porte sur l’artefact
+réellement construit et publié.
+
+## 1. Résultat attendu
+
+Une exécution réussie produit un kit hors du dépôt :
+
+```text
+<dossier-de-sortie>/
+├── artifacts/
+│   └── sonar_<version>_x64-setup.exe
+├── provenance/
+│   ├── sonar-windows-nsis-provenance.slsa-v1.json
+│   └── <installateur>.provenance.sigstore.json
+├── signatures/
+│   ├── <installateur>.sigstore.json
+│   └── SHA256SUMS.sigstore.json
+├── trust/
+│   ├── cosign-sonar.pub
+│   └── cosign-tsa-chain.pem       # seulement si demandé
+├── logs/
+│   └── build.log
+├── metadata.json
+├── SHA256SUMS
+└── VERIFY.txt
+```
+
+L’installateur final possède donc deux protections complémentaires :
+
+- une signature native Authenticode, reconnue par Windows et horodatée ;
+- une signature Cosign et une provenance SLSA liées à son SHA-256 exact.
+
+Le manifeste `SHA256SUMS` est lui-même signé. Le journal `logs/build.log`, qui
+continue d’évoluer jusqu’à la fin du script, est volontairement exclu du
+manifeste signé et doit être traité comme une trace d’audit séparée.
+
+## 2. Prérequis du poste Windows
+
+Le poste de release doit disposer de :
+
+- Windows x86_64 et PowerShell 7.2 ou plus récent ;
+- Git, Node.js, Deno, Rust/Cargo, Tauri CLI et Cosign ;
+- Windows SDK avec `signtool.exe` x64 ;
+- 7-Zip ;
+- le middleware du HSM Authenticode ;
+- l’accès au HSM ou à la clé matérielle utilisée par Cosign ;
+- l’accès à un serveur d’horodatage RFC 3161 ;
+- les autorités de certification de l’entreprise et du serveur d’horodatage
+  installées dans les magasins de confiance Windows.
+
+Les versions Node, Deno, Rust, Tauri et Cosign doivent être exactement celles de
+`config/build-versions.env`. Le script les vérifie avant de compiler.
+
+Sur un poste sans accès à Internet, les dépendances Deno, Cargo, Tauri et NSIS
+doivent déjà être présentes dans les caches du compte de build. Le HSM/KMS et le
+serveur d’horodatage doivent être locaux ou accessibles sur le réseau interne.
+Une URL de TSA publique ne fonctionnera pas depuis un poste totalement isolé.
+
+## 3. Préparer les identités de signature
+
+### 3.1 Certificat Authenticode
+
+Le certificat de signature de code doit être installé dans l’un de ces
+magasins :
+
+- `Cert:\CurrentUser\My` ;
+- `Cert:\LocalMachine\My`.
+
+Il doit être valide, autoriser l’usage « signature de code » et être relié à la
+clé privée conservée dans le HSM. Pour afficher les certificats disponibles :
+
+```powershell
+Get-ChildItem Cert:\LocalMachine\My |
+  Select-Object Subject, Thumbprint, NotBefore, NotAfter, HasPrivateKey
+```
+
+Conserver l’empreinte SHA-1 sans espace :
+
+```powershell
+$authenticodeThumbprint = "0123456789ABCDEF0123456789ABCDEF01234567"
+Get-Item "Cert:\LocalMachine\My\$authenticodeThumbprint" |
+  Format-List Subject, Issuer, Thumbprint, NotBefore, NotAfter, HasPrivateKey
+```
+
+Lorsque le middleware relie correctement le certificat à sa clé, l’empreinte et
+le magasin suffisent. Certains HSM imposent aussi le nom du CSP/KSP et celui du
+conteneur de clé. Dans ce cas, ajouter ensemble :
+
+```powershell
+-SignToolCsp "Nom du fournisseur HSM" `
+-SignToolKeyContainer "Nom du conteneur"
+```
+
+Ces deux valeurs viennent de la configuration du middleware HSM. Elles ne
+doivent pas être inventées ou remplacées par un chemin de clé privée.
+
+### 3.2 Clé de provenance Cosign
+
+La provenance utilise une clé distincte. Deux modes sont possibles.
+
+Mode HSM/KMS par référence :
+
+```powershell
+-CosignKeyReference "azurekms://coffre/cle-sonar-provenance"
+```
+
+Cosign accepte notamment les références `azurekms://`, `awskms://`,
+`gcpkms://`, `hashivault://` et, avec le fournisseur adapté, `pkcs11:`. Le
+script refuse un chemin vers une clé privée locale.
+
+Mode clé matérielle PIV compatible Cosign :
+
+```powershell
+-CosignSecurityKey
+```
+
+Dans les deux cas, exporter uniquement la clé publique dans un emplacement de
+confiance :
+
+```powershell
+-CosignPublicKey "C:\SONAR-TRUST\cosign-sonar.pub"
+```
+
+Cette clé publique doit aussi être remise aux vérificateurs par un canal séparé
+du kit de release. Copier une clé publique uniquement depuis le kit ne permet
+pas d’établir sa confiance initiale.
+
+## 4. Préparer la source approuvée
+
+Le script exige :
+
+- un tag au format `vX.Y.Z` ;
+- la même version dans le tag, `package.json` et
+  `src-tauri/tauri.conf.json` ;
+- un `HEAD` exactement égal au commit approuvé ;
+- un tag signé et vérifiable avec `git tag -v` ;
+- aucun fichier modifié ou non suivi.
+
+Depuis une copie fraîche du dépôt :
+
+```powershell
+Set-Location C:\SONAR-BUILD\Sonar_desktop_app
+
+$tag = "v4.8.3"
+$expectedCommit = "0123456789abcdef0123456789abcdef01234567"
+
+git tag -v $tag
+git switch --detach $tag
+git rev-parse HEAD
+git status --short
+```
+
+La valeur de `$expectedCommit` doit venir de la validation de release ou d’un
+canal indépendant, pas uniquement du dépôt présent sur la machine. Les sorties
+de `git rev-parse HEAD` et `git status --short` doivent respectivement être le
+commit approuvé et une sortie vide.
+
+Par défaut, un tag non signé arrête le build. `-AllowUnsignedTag` existe
+uniquement comme dérogation documentée ; il ne doit pas être utilisé pour une
+release officielle normale.
+
+## 5. Lancer la commande
+
+### 5.1 Avec une référence HSM/KMS Cosign
+
+```powershell
+Set-Location C:\SONAR-BUILD\Sonar_desktop_app
+
+$tag = "v4.8.3"
+$expectedCommit = "0123456789abcdef0123456789abcdef01234567"
+$authenticodeThumbprint = "89ABCDEF0123456789ABCDEF0123456789ABCDEF"
+$releaseDirectory = "C:\SONAR-RELEASES\$tag"
+
+.\script\release\win_officiel_builder_hsm_prov.ps1 `
+  -ReleaseTag $tag `
+  -ExpectedCommit $expectedCommit `
+  -AuthenticodeThumbprint $authenticodeThumbprint `
+  -CertificateStore LocalMachine `
+  -TimestampUrl "https://tsa.entreprise.example/rfc3161" `
+  -CosignKeyReference "azurekms://coffre/cle-sonar-provenance" `
+  -CosignPublicKey "C:\SONAR-TRUST\cosign-sonar.pub" `
+  -OutputDirectory $releaseDirectory
+```
+
+### 5.2 Avec une clé matérielle Cosign
+
+Remplacer `-CosignKeyReference` par `-CosignSecurityKey` :
+
+```powershell
+.\script\release\win_officiel_builder_hsm_prov.ps1 `
+  -ReleaseTag $tag `
+  -ExpectedCommit $expectedCommit `
+  -AuthenticodeThumbprint $authenticodeThumbprint `
+  -CertificateStore LocalMachine `
+  -TimestampUrl "https://tsa.entreprise.example/rfc3161" `
+  -CosignSecurityKey `
+  -CosignPublicKey "C:\SONAR-TRUST\cosign-sonar.pub" `
+  -OutputDirectory $releaseDirectory
+```
+
+Le dossier de sortie doit être absolu, extérieur au dépôt et vide ou inexistant.
+En cas d’échec, le kit partiel est conservé pour l’analyse. Utiliser un nouveau
+dossier vide pour la tentative suivante après avoir archivé ou supprimé le kit
+partiel selon la procédure interne.
+
+Le HSM peut demander son PIN plusieurs fois : lors du préflight Cosign, de la
+signature de l’exécutable, de la création de l’installateur, de la provenance et
+du manifeste. Saisir le PIN uniquement dans l’interface sécurisée du middleware
+ou du token. Ne jamais le passer en paramètre, en variable d’environnement ou
+dans un fichier du dépôt.
+
+### 5.3 Paramètres complémentaires
+
+| Paramètre | Usage |
+| --- | --- |
+| `-CertificateStore CurrentUser` | Sélectionne le magasin du compte de build ; c’est la valeur par défaut |
+| `-CertificateStore LocalMachine` | Sélectionne le magasin de la machine et ajoute `/sm` à SignTool |
+| `-SignToolCsp` et `-SignToolKeyContainer` | Indiquent explicitement le fournisseur et le conteneur HSM ; toujours les fournir ensemble |
+| `-SourceRepositoryUri` | Fixe l’URI inscrite dans la provenance quand elle ne doit pas être déduite du remote Git |
+| `-BuilderId` | Remplace l’identité SLSA par défaut `urn:sonar:builder:windows-hsm:v1` |
+| `-UseLegacyAuthenticodeTimestamp` | Utilise l’ancien protocole Authenticode `/t` au lieu de RFC 3161 ; uniquement pour une TSA interne ancienne |
+| `-AllowUnsignedTag` | Dérogation permettant un tag non signé ; interdite dans le processus officiel normal |
+
+Pour afficher l’aide intégrée et tous les paramètres :
+
+```powershell
+Get-Help .\script\release\win_officiel_builder_hsm_prov.ps1 -Full
+```
+
+## 6. Horodatage Cosign facultatif
+
+La signature Authenticode est toujours horodatée. Pour horodater aussi les
+preuves Cosign, fournir ensemble l’URL RFC 3161 et sa chaîne de certificats :
+
+```powershell
+-CosignTimestampUrl "https://tsa.entreprise.example/rfc3161" `
+-CosignTimestampCertificateChain "C:\SONAR-TRUST\tsa-chain.pem"
+```
+
+Le script copie la chaîne dans le kit puis exige que l’horodatage Cosign soit
+validé. Ne fournir qu’un seul de ces deux paramètres provoque un arrêt.
+
+## 7. Contrôles réalisés automatiquement
+
+Avant de produire le kit, le script :
+
+1. vérifie le système Windows, les outils et leurs versions ;
+2. vérifie le tag, le commit, les versions applicatives et la propreté Git ;
+3. vérifie le certificat Authenticode et son usage de signature de code ;
+4. signe puis vérifie un petit fichier de préflight avec la clé Cosign ;
+5. exécute `deno install --frozen`, le typecheck, le lint et les tests ;
+6. exécute les tests Rust avec `cargo test --locked` ;
+7. construit seulement l’installateur NSIS dans un répertoire temporaire ;
+8. vérifie à nouveau le commit et la propreté Git après le build ;
+9. contrôle la structure PE, l’import de `wpcap.dll` et l’absence d’un
+   installateur Npcap/WinPcap embarqué ;
+10. vérifie la signature Authenticode, l’empreinte du signataire et
+    l’horodatage de l’exécutable et de l’installateur ;
+11. signe l’installateur, la provenance SLSA et le manifeste avec Cosign ;
+12. vérifie immédiatement toutes les preuves avec la clé publique fournie.
+
+Une étape en erreur arrête le processus. Aucune provenance n’est signée si le
+build a modifié la source approuvée.
+
+## 8. Vérifier le kit avant publication
+
+Depuis la racine du kit, suivre `VERIFY.txt`. L’ordre important est :
+
+1. comparer `trust/cosign-sonar.pub` avec la clé publique de référence obtenue
+   par un canal indépendant ;
+2. vérifier la signature Cosign de `SHA256SUMS` ;
+3. recalculer les empreintes des fichiers listés ;
+4. vérifier Authenticode avec SignTool ;
+5. vérifier la signature Cosign de l’installateur ;
+6. vérifier l’attestation SLSA et son sujet.
+
+Exemples principaux :
+
+```powershell
+Set-Location C:\SONAR-RELEASES\v4.8.3
+
+cosign verify-blob `
+  --private-infrastructure `
+  --key "trust\cosign-sonar.pub" `
+  --bundle "signatures\SHA256SUMS.sigstore.json" `
+  "SHA256SUMS"
+
+signtool verify /pa /all /v /tw "artifacts\sonar_4.8.3_x64-setup.exe"
+
+cosign verify-blob-attestation `
+  --private-infrastructure `
+  --key "trust\cosign-sonar.pub" `
+  --bundle "provenance\sonar_4.8.3_x64-setup.exe.provenance.sigstore.json" `
+  --type slsaprovenance1 `
+  "artifacts\sonar_4.8.3_x64-setup.exe"
+```
+
+Utiliser les noms réels indiqués dans `VERIFY.txt` et `metadata.json`. Si
+l’horodatage Cosign a été activé, `VERIFY.txt` ajoute automatiquement les
+paramètres nécessaires à sa vérification.
+
+## 9. Diagnostic des erreurs courantes
+
+| Erreur | Cause probable | Action |
+| --- | --- | --- |
+| Le script exige Windows | Commande lancée sur Linux ou macOS | Utiliser le poste Windows officiel |
+| Dépôt non propre | Fichier modifié ou non suivi | Identifier la différence ; ne pas la masquer avant validation |
+| Échec de `git tag -v` | Tag non signé ou clé du signataire absente | Importer la clé de confiance ou refaire le tag selon la procédure |
+| Version d’outil incorrecte | Poste non aligné sur `build-versions.env` | Installer la version exacte attendue |
+| Certificat introuvable | Mauvais magasin ou mauvaise empreinte | Contrôler `CertificateStore` et l’empreinte sans espace |
+| Aucune clé privée | Middleware HSM absent ou association certificat/clé incorrecte | Corriger le middleware ; utiliser CSP/conteneur si requis |
+| Échec SignTool | HSM verrouillé, PIN refusé, TSA inaccessible ou chaîne non fiable | Contrôler le token, le réseau interne, les CA et la révocation |
+| Échec du préflight Cosign | Mauvaise référence, token absent ou clé publique non correspondante | Corriger la référence et comparer la clé publique de confiance |
+| Source modifiée après build | Lockfile ou fichier suivi réécrit pendant la compilation | Examiner le diff ; ne pas publier le kit partiel |
+| Dossier de sortie non vide | Ancienne tentative présente | Archiver la tentative puis choisir un nouveau dossier vide |
+
+## 10. Checklist de publication
+
+- [ ] Le tag signé et le commit ont été approuvés par une seconde personne.
+- [ ] Le dépôt était propre avant et après le build.
+- [ ] Les tests du script sont tous réussis.
+- [ ] L’empreinte Authenticode correspond au certificat officiel de
+      l’entreprise.
+- [ ] La clé publique Cosign correspond à la copie de confiance indépendante.
+- [ ] La signature du manifeste, les empreintes, Authenticode et la provenance
+      ont été vérifiés depuis le kit final.
+- [ ] `metadata.json` contient le tag et le commit attendus.
+- [ ] Le kit complet est archivé et publié ; l’installateur n’est pas diffusé
+      seul sans ses preuves.
+- [ ] Le journal de build est conservé selon la politique interne et son accès
+      est limité, car il peut contenir des chemins locaux et l’identité du
+      certificat.

--- a/script/release/win_officiel_builder_hsm_prov.ps1
+++ b/script/release/win_officiel_builder_hsm_prov.ps1
@@ -1,0 +1,777 @@
+#Requires -Version 7.2
+
+<#
+.SYNOPSIS
+Construit la version Windows NSIS officielle de SONAR et produit ses preuves.
+
+.DESCRIPTION
+Ce script est destine au poste Windows securise de release. Il :
+
+1. verifie le tag, le commit, la proprete Git et les versions d'outils ;
+2. execute les controles applicatifs puis construit uniquement l'installateur NSIS ;
+3. fait signer par Tauri l'executable et l'installateur avec SignTool et le
+   certificat Authenticode expose par le HSM dans le magasin Windows ;
+4. verifie les signatures Authenticode et leur horodatage ;
+5. genere une provenance SLSA v1, la signe avec Cosign via un HSM/KMS ou une
+   cle de securite, puis verifie immediatement la preuve avec la cle publique ;
+6. cree un kit autonome contenant l'installateur, les preuves et les empreintes.
+
+La cle privee Authenticode et la cle Cosign ne sont jamais exportees. Le script
+ne pretend pas rendre le build reproductible : il atteste quel code et quels
+outils ont produit l'artefact effectivement livre.
+
+Le poste peut etre deconnecte d'Internet si les dependances Deno/Cargo/NSIS sont
+deja presentes et si les services HSM/KMS et TSA requis restent accessibles.
+
+.PARAMETER ReleaseTag
+Tag Git de release au format vX.Y.Z. La version doit correspondre a package.json
+et src-tauri/tauri.conf.json.
+
+.PARAMETER ExpectedCommit
+SHA-1 Git complet (40 caracteres) approuve pour la release.
+
+.PARAMETER AuthenticodeThumbprint
+Empreinte SHA-1 du certificat de signature de code installe dans le magasin
+Windows et relie a la cle privee du HSM.
+
+.PARAMETER CertificateStore
+Magasin contenant le certificat : CurrentUser (defaut) ou LocalMachine.
+
+.PARAMETER TimestampUrl
+URL du serveur d'horodatage Authenticode. RFC 3161 est utilise par defaut.
+
+.PARAMETER SignToolCsp
+Nom du CSP/KSP du HSM. Facultatif ; a fournir avec SignToolKeyContainer lorsque
+le middleware HSM ne relie pas directement la cle privee au certificat.
+
+.PARAMETER SignToolKeyContainer
+Nom du conteneur de cle du HSM. Facultatif ; a fournir avec SignToolCsp.
+
+.PARAMETER CosignKeyReference
+Reference HSM/KMS acceptee par Cosign, par exemple azurekms://, awskms://,
+gcpkms://, hashivault:// ou pkcs11:. Les chemins de cles locales sont refuses.
+
+.PARAMETER CosignSecurityKey
+Utilise le mode --sk de Cosign pour une cle materielle compatible PIV. Ce mode
+forme un jeu de parametres alternatif a CosignKeyReference.
+
+.PARAMETER CosignPublicKey
+Cle publique PEM correspondant a la cle Cosign du HSM. Elle est copiee dans le
+kit et utilisee pour verifier la signature et la provenance avant publication.
+
+.PARAMETER OutputDirectory
+Repertoire absolu, hors du depot, dans lequel creer le kit. Il doit etre vide ou
+inexistant. Un kit partiel est conserve en cas d'echec pour faciliter l'audit.
+
+.PARAMETER AllowUnsignedTag
+Mode derogatoire : autorise un tag Git non signe. Sans ce commutateur, la
+signature du tag doit etre validee par `git tag -v` sur le poste de release.
+
+.EXAMPLE
+./script/release/win_officiel_builder_hsm_prov.ps1 `
+  -ReleaseTag v4.8.3 `
+  -ExpectedCommit 0123456789abcdef0123456789abcdef01234567 `
+  -AuthenticodeThumbprint 89ABCDEF0123456789ABCDEF0123456789ABCDEF `
+  -CertificateStore LocalMachine `
+  -TimestampUrl https://tsa.entreprise.example/rfc3161 `
+  -CosignKeyReference 'azurekms://coffre.example.net/cles/sonar-provenance' `
+  -CosignPublicKey C:\SONAR-TRUST\cosign-sonar.pub `
+  -OutputDirectory C:\SONAR-RELEASES\v4.8.3
+
+.NOTES
+Prerequis : PowerShell 7.2+, Git, Node, Deno, Rust/Cargo, Tauri CLI, Cosign,
+SignTool, 7-Zip, middleware HSM et acces au serveur TSA. Les versions attendues
+sont celles de config/build-versions.env.
+
+.LINK
+script/release/WIN_OFFICIEL_BUILDER_HSM_PROV.md
+#>
+
+[CmdletBinding(DefaultParameterSetName = "HsmReference")]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^v[0-9]+\.[0-9]+\.[0-9]+$')]
+  [string] $ReleaseTag,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9a-fA-F]{40}$')]
+  [string] $ExpectedCommit,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9a-fA-F]{40}$')]
+  [string] $AuthenticodeThumbprint,
+
+  [ValidateSet("CurrentUser", "LocalMachine")]
+  [string] $CertificateStore = "CurrentUser",
+
+  [Parameter(Mandatory = $true)]
+  [uri] $TimestampUrl,
+
+  [switch] $UseLegacyAuthenticodeTimestamp,
+
+  [string] $SignToolCsp,
+
+  [string] $SignToolKeyContainer,
+
+  [Parameter(Mandatory = $true, ParameterSetName = "HsmReference")]
+  [string] $CosignKeyReference,
+
+  [Parameter(Mandatory = $true, ParameterSetName = "SecurityKey")]
+  [switch] $CosignSecurityKey,
+
+  [Parameter(Mandatory = $true)]
+  [string] $CosignPublicKey,
+
+  [uri] $CosignTimestampUrl,
+
+  [string] $CosignTimestampCertificateChain,
+
+  [Parameter(Mandatory = $true)]
+  [string] $OutputDirectory,
+
+  [string] $BuilderId = "urn:sonar:builder:windows-hsm:v1",
+
+  [string] $SourceRepositoryUri,
+
+  [switch] $AllowUnsignedTag
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Invoke-External {
+  param(
+    [Parameter(Mandatory = $true)] [string] $FilePath,
+    [string[]] $ArgumentList = @(),
+    [Parameter(Mandatory = $true)] [string] $WorkingDirectory,
+    [Parameter(Mandatory = $true)] [string] $Description
+  )
+
+  Write-Host "==> $Description"
+  Push-Location -LiteralPath $WorkingDirectory
+  try {
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+      throw "$Description a echoue avec le code $LASTEXITCODE."
+    }
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+function Get-ExternalOutput {
+  param(
+    [Parameter(Mandatory = $true)] [string] $FilePath,
+    [string[]] $ArgumentList = @(),
+    [Parameter(Mandatory = $true)] [string] $WorkingDirectory,
+    [Parameter(Mandatory = $true)] [string] $Description
+  )
+
+  Push-Location -LiteralPath $WorkingDirectory
+  try {
+    $lines = @(& $FilePath @ArgumentList 2>&1)
+    $exitCode = $LASTEXITCODE
+    $output = ($lines | ForEach-Object { $_.ToString() }) -join "`n"
+    if ($exitCode -ne 0) {
+      throw "$Description a echoue avec le code ${exitCode}:`n$output"
+    }
+    return $output.Trim()
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+function Get-RequiredCommandPath {
+  param([Parameter(Mandatory = $true)] [string] $Name)
+
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if (-not $command) {
+    throw "Commande requise introuvable : $Name"
+  }
+  return $command.Source
+}
+
+function Get-SignToolPath {
+  $command = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+  if ($command) {
+    return $command.Source
+  }
+
+  $programFilesX86 = ${env:ProgramFiles(x86)}
+  if ($programFilesX86) {
+    $kitsBin = Join-Path $programFilesX86 "Windows Kits\10\bin"
+    if (Test-Path -LiteralPath $kitsBin) {
+      $candidate = Get-ChildItem -LiteralPath $kitsBin -Filter "signtool.exe" -File -Recurse |
+        Where-Object { $_.FullName -match '[\\/]x64[\\/]signtool\.exe$' } |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1
+      if ($candidate) {
+        return $candidate.FullName
+      }
+    }
+  }
+
+  throw "signtool.exe x64 est introuvable. Installez le Windows SDK."
+}
+
+function Read-BuildVersions {
+  param([Parameter(Mandatory = $true)] [string] $Path)
+
+  $versions = @{}
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    if ($line -match '^([A-Z0-9_]+)=(.*)$') {
+      $value = $Matches[2].Trim()
+      if ($value.Length -ge 2 -and $value.StartsWith('"') -and $value.EndsWith('"')) {
+        $value = $value.Substring(1, $value.Length - 2)
+      }
+      $versions[$Matches[1]] = $value
+    }
+  }
+  return $versions
+}
+
+function Get-VersionMatch {
+  param(
+    [Parameter(Mandatory = $true)] [string] $Text,
+    [Parameter(Mandatory = $true)] [string] $Pattern,
+    [Parameter(Mandatory = $true)] [string] $ToolName
+  )
+
+  $match = [regex]::Match($Text, $Pattern, [Text.RegularExpressions.RegexOptions]::IgnoreCase)
+  if (-not $match.Success) {
+    throw "Impossible de lire la version de $ToolName dans : $Text"
+  }
+  return $match.Groups[1].Value
+}
+
+function Assert-Version {
+  param(
+    [Parameter(Mandatory = $true)] [string] $Name,
+    [Parameter(Mandatory = $true)] [string] $Actual,
+    [Parameter(Mandatory = $true)] [string] $Expected
+  )
+
+  if ($Actual -ne $Expected) {
+    throw "Version $Name incorrecte : attendue $Expected, trouvee $Actual."
+  }
+  Write-Host "Version $Name validee : $Actual"
+}
+
+function Get-Sha256 {
+  param([Parameter(Mandatory = $true)] [string] $Path)
+  return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Assert-AuthenticodeSignature {
+  param(
+    [Parameter(Mandatory = $true)] [string] $Path,
+    [Parameter(Mandatory = $true)] [string] $ExpectedThumbprint,
+    [Parameter(Mandatory = $true)] [string] $SignToolPath,
+    [Parameter(Mandatory = $true)] [string] $WorkingDirectory
+  )
+
+  Invoke-External -FilePath $SignToolPath `
+    -ArgumentList @("verify", "/pa", "/all", "/v", "/tw", $Path) `
+    -WorkingDirectory $WorkingDirectory `
+    -Description "Verification SignTool de $(Split-Path -Leaf $Path)"
+
+  $signature = Get-AuthenticodeSignature -LiteralPath $Path
+  if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+    throw "Signature Authenticode invalide pour ${Path}: $($signature.StatusMessage)"
+  }
+  if (-not $signature.SignerCertificate) {
+    throw "Aucun certificat signataire trouve pour $Path"
+  }
+  if ($signature.SignerCertificate.Thumbprint.ToUpperInvariant() -ne $ExpectedThumbprint) {
+    throw "Le certificat signataire de $Path ne correspond pas a l'empreinte approuvee."
+  }
+  if (-not $signature.TimeStamperCertificate) {
+    throw "La signature de $Path ne contient pas d'horodatage."
+  }
+}
+
+if (-not $IsWindows) {
+  throw "Ce script doit etre execute sur le poste Windows officiel de build."
+}
+
+if ($TimestampUrl.Scheme -notin @("http", "https")) {
+  throw "TimestampUrl doit etre une URL HTTP(S)."
+}
+if (($SignToolCsp -and -not $SignToolKeyContainer) -or
+    ($SignToolKeyContainer -and -not $SignToolCsp)) {
+  throw "SignToolCsp et SignToolKeyContainer doivent etre fournis ensemble."
+}
+if ($PSCmdlet.ParameterSetName -eq "HsmReference" -and
+    $CosignKeyReference -notmatch '^(?:[a-z][a-z0-9+.-]*://|pkcs11:)') {
+  throw "CosignKeyReference doit etre une reference HSM/KMS, pas un chemin de cle locale."
+}
+if (($CosignTimestampUrl -and -not $CosignTimestampCertificateChain) -or
+    ($CosignTimestampCertificateChain -and -not $CosignTimestampUrl)) {
+  throw "CosignTimestampUrl et CosignTimestampCertificateChain doivent etre fournis ensemble."
+}
+if ($CosignTimestampUrl -and $CosignTimestampUrl.Scheme -notin @("http", "https")) {
+  throw "CosignTimestampUrl doit etre une URL HTTP(S)."
+}
+
+$scriptPath = $MyInvocation.MyCommand.Path
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
+$tauriDirectory = Join-Path $repositoryRoot "src-tauri"
+$buildVersionsPath = Join-Path $repositoryRoot "config\build-versions.env"
+$cosignPublicKeyPath = (Resolve-Path -LiteralPath $CosignPublicKey).Path
+$cosignTimestampChainPath = if ($CosignTimestampCertificateChain) {
+  (Resolve-Path -LiteralPath $CosignTimestampCertificateChain).Path
+} else {
+  $null
+}
+
+if (-not [IO.Path]::IsPathFullyQualified($OutputDirectory)) {
+  throw "OutputDirectory doit etre un chemin absolu."
+}
+$outputPath = [IO.Path]::GetFullPath($OutputDirectory)
+$repositoryPrefix = $repositoryRoot.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) +
+  [IO.Path]::DirectorySeparatorChar
+if ($outputPath.Equals($repositoryRoot, [StringComparison]::OrdinalIgnoreCase) -or
+    $outputPath.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+  throw "OutputDirectory doit etre situe hors du depot source."
+}
+if (Test-Path -LiteralPath $outputPath) {
+  if (Get-ChildItem -LiteralPath $outputPath -Force | Select-Object -First 1) {
+    throw "OutputDirectory existe deja et n'est pas vide : $outputPath"
+  }
+} else {
+  New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
+}
+
+$artifactDirectory = New-Item -ItemType Directory -Path (Join-Path $outputPath "artifacts")
+$provenanceDirectory = New-Item -ItemType Directory -Path (Join-Path $outputPath "provenance")
+$signatureDirectory = New-Item -ItemType Directory -Path (Join-Path $outputPath "signatures")
+$trustDirectory = New-Item -ItemType Directory -Path (Join-Path $outputPath "trust")
+$logDirectory = New-Item -ItemType Directory -Path (Join-Path $outputPath "logs")
+$transcriptPath = Join-Path $logDirectory "build.log"
+$workDirectory = Join-Path ([IO.Path]::GetTempPath()) ("sonar-win-officiel-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $workDirectory | Out-Null
+
+$previousCargoTargetDirectory = $env:CARGO_TARGET_DIR
+$previousCi = $env:CI
+$transcriptStarted = $false
+$buildSucceeded = $false
+
+try {
+  Start-Transcript -LiteralPath $transcriptPath | Out-Null
+  $transcriptStarted = $true
+
+  $git = Get-RequiredCommandPath "git"
+  $deno = Get-RequiredCommandPath "deno"
+  $node = Get-RequiredCommandPath "node"
+  $rustc = Get-RequiredCommandPath "rustc"
+  $cargo = Get-RequiredCommandPath "cargo"
+  $cosign = Get-RequiredCommandPath "cosign"
+  $signTool = Get-SignToolPath
+  $pwsh = Get-RequiredCommandPath "pwsh"
+
+  $expectedCommitNormalized = $ExpectedCommit.ToLowerInvariant()
+  $authenticodeThumbprintNormalized = $AuthenticodeThumbprint.ToUpperInvariant()
+  $headCommit = (Get-ExternalOutput -FilePath $git -ArgumentList @("rev-parse", "HEAD") `
+    -WorkingDirectory $repositoryRoot -Description "Lecture du commit HEAD").ToLowerInvariant()
+  if ($headCommit -ne $expectedCommitNormalized) {
+    throw "HEAD ($headCommit) ne correspond pas au commit approuve ($expectedCommitNormalized)."
+  }
+
+  $tagCommit = (Get-ExternalOutput -FilePath $git -ArgumentList @("rev-parse", "$ReleaseTag^{commit}") `
+    -WorkingDirectory $repositoryRoot -Description "Resolution du tag $ReleaseTag").ToLowerInvariant()
+  if ($tagCommit -ne $expectedCommitNormalized) {
+    throw "Le tag $ReleaseTag pointe vers $tagCommit au lieu de $expectedCommitNormalized."
+  }
+  if (-not $AllowUnsignedTag) {
+    [void](Get-ExternalOutput -FilePath $git -ArgumentList @("tag", "-v", $ReleaseTag) `
+      -WorkingDirectory $repositoryRoot -Description "Verification cryptographique du tag $ReleaseTag")
+  } else {
+    Write-Warning "DEROGATION : la signature du tag Git n'est pas exigee."
+  }
+
+  $gitStatus = Get-ExternalOutput -FilePath $git `
+    -ArgumentList @("status", "--porcelain=v1", "--untracked-files=all") `
+    -WorkingDirectory $repositoryRoot -Description "Verification de la proprete Git"
+  if ($gitStatus) {
+    throw "Le depot doit etre strictement propre avant un build officiel :`n$gitStatus"
+  }
+
+  $releaseVersion = $ReleaseTag.Substring(1)
+  $packageConfig = Get-Content -LiteralPath (Join-Path $repositoryRoot "package.json") -Raw | ConvertFrom-Json
+  $tauriConfig = Get-Content -LiteralPath (Join-Path $tauriDirectory "tauri.conf.json") -Raw | ConvertFrom-Json
+  if ($packageConfig.version -ne $releaseVersion -or $tauriConfig.version -ne $releaseVersion) {
+    throw "Le tag $ReleaseTag, package.json ($($packageConfig.version)) et tauri.conf.json ($($tauriConfig.version)) doivent avoir la meme version."
+  }
+
+  if (-not $SourceRepositoryUri) {
+    $remoteNames = @(Get-ExternalOutput -FilePath $git -ArgumentList @("remote") `
+      -WorkingDirectory $repositoryRoot -Description "Lecture des remotes Git" -ErrorAction Stop) -split "`n"
+    $remoteName = if ($remoteNames -contains "origin") { "origin" } else { $remoteNames[0].Trim() }
+    if (-not $remoteName) {
+      throw "Aucun remote Git disponible ; fournissez SourceRepositoryUri."
+    }
+    $SourceRepositoryUri = Get-ExternalOutput -FilePath $git -ArgumentList @("remote", "get-url", $remoteName) `
+      -WorkingDirectory $repositoryRoot -Description "Lecture de l'URL source"
+  }
+
+  $versions = Read-BuildVersions -Path $buildVersionsPath
+  foreach ($requiredVersion in @("RUST_VERSION", "NODE_VERSION", "DENO_VERSION", "TAURI_CLI_VERSION", "COSIGN_VERSION")) {
+    if (-not $versions.ContainsKey($requiredVersion)) {
+      throw "Version canonique absente de config/build-versions.env : $requiredVersion"
+    }
+  }
+
+  $denoOutput = Get-ExternalOutput -FilePath $deno -ArgumentList @("--version") `
+    -WorkingDirectory $repositoryRoot -Description "Lecture de la version Deno"
+  $nodeOutput = Get-ExternalOutput -FilePath $node -ArgumentList @("--version") `
+    -WorkingDirectory $repositoryRoot -Description "Lecture de la version Node"
+  $rustOutput = Get-ExternalOutput -FilePath $rustc -ArgumentList @("--version") `
+    -WorkingDirectory $repositoryRoot -Description "Lecture de la version Rust"
+  $tauriOutput = Get-ExternalOutput -FilePath $deno -ArgumentList @("task", "tauri", "--version") `
+    -WorkingDirectory $repositoryRoot -Description "Lecture de la version Tauri CLI"
+  $cosignOutput = Get-ExternalOutput -FilePath $cosign -ArgumentList @("version") `
+    -WorkingDirectory $repositoryRoot -Description "Lecture de la version Cosign"
+
+  $actualVersions = [ordered]@{
+    deno = Get-VersionMatch -Text $denoOutput -Pattern '(?m)^deno\s+v?([0-9]+\.[0-9]+\.[0-9]+)' -ToolName "Deno"
+    node = Get-VersionMatch -Text $nodeOutput -Pattern '^v?([0-9]+\.[0-9]+\.[0-9]+)' -ToolName "Node"
+    rust = Get-VersionMatch -Text $rustOutput -Pattern '^rustc\s+([0-9]+\.[0-9]+\.[0-9]+)' -ToolName "Rust"
+    tauri = Get-VersionMatch -Text $tauriOutput -Pattern '(?m)(?:tauri-cli|tauri)\s+v?([0-9]+\.[0-9]+\.[0-9]+)' -ToolName "Tauri CLI"
+    cosign = Get-VersionMatch -Text $cosignOutput -Pattern '(?m)GitVersion:\s*v?([0-9]+\.[0-9]+\.[0-9]+)' -ToolName "Cosign"
+  }
+  Assert-Version -Name "Deno" -Actual $actualVersions.deno -Expected $versions.DENO_VERSION
+  Assert-Version -Name "Node" -Actual $actualVersions.node -Expected $versions.NODE_VERSION
+  Assert-Version -Name "Rust" -Actual $actualVersions.rust -Expected $versions.RUST_VERSION
+  Assert-Version -Name "Tauri CLI" -Actual $actualVersions.tauri -Expected $versions.TAURI_CLI_VERSION
+  Assert-Version -Name "Cosign" -Actual $actualVersions.cosign -Expected $versions.COSIGN_VERSION
+
+  $certificatePath = "Cert:\$CertificateStore\My\$authenticodeThumbprintNormalized"
+  if (-not (Test-Path -LiteralPath $certificatePath)) {
+    throw "Certificat Authenticode introuvable : $certificatePath"
+  }
+  $certificate = Get-Item -LiteralPath $certificatePath
+  $now = Get-Date
+  if ($now -lt $certificate.NotBefore -or $now -gt $certificate.NotAfter) {
+    throw "Le certificat Authenticode n'est pas valide a la date du build."
+  }
+  if (-not $certificate.HasPrivateKey -and -not $SignToolCsp) {
+    throw "Le certificat n'expose aucune cle privee. Verifiez le middleware HSM ou fournissez SignToolCsp et SignToolKeyContainer."
+  }
+  $ekuOids = @($certificate.EnhancedKeyUsageList | ForEach-Object { $_.ObjectId.Value })
+  if ($ekuOids.Count -gt 0 -and $ekuOids -notcontains "1.3.6.1.5.5.7.3.3") {
+    throw "Le certificat selectionne n'autorise pas la signature de code."
+  }
+  Write-Host "Certificat Authenticode valide : $($certificate.Subject)"
+
+  $invocationId = [guid]::NewGuid().ToString()
+  $cosignSignerArguments = if ($PSCmdlet.ParameterSetName -eq "SecurityKey") {
+    @("--sk")
+  } else {
+    @("--key", $CosignKeyReference)
+  }
+  $cosignTimestampArguments = if ($CosignTimestampUrl) {
+    @("--timestamp-server-url", $CosignTimestampUrl.AbsoluteUri)
+  } else {
+    @()
+  }
+  $preflightTimestampVerificationArguments = if ($cosignTimestampChainPath) {
+    @("--use-signed-timestamps", "--timestamp-certificate-chain", $cosignTimestampChainPath)
+  } else {
+    @()
+  }
+  $cosignPreflightPath = Join-Path $workDirectory "cosign-hsm-preflight.txt"
+  $cosignPreflightBundle = Join-Path $workDirectory "cosign-hsm-preflight.sigstore.json"
+  "SONAR official builder preflight $invocationId $expectedCommitNormalized" |
+    Set-Content -LiteralPath $cosignPreflightPath -Encoding utf8NoBOM
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("sign-blob", "--yes", "--use-signing-config=false", "--new-bundle-format=true", "--bundle", $cosignPreflightBundle) +
+      $cosignSignerArguments + $cosignTimestampArguments + @($cosignPreflightPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Preflight de la cle Cosign HSM"
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("verify-blob", "--private-infrastructure", "--key", $cosignPublicKeyPath, "--bundle", $cosignPreflightBundle) +
+      $preflightTimestampVerificationArguments + @($cosignPreflightPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Verification de la cle publique Cosign"
+
+  $targetDirectory = Join-Path $workDirectory "target"
+  $overlayPath = Join-Path $workDirectory "tauri.windows.official.json"
+  $signArguments = @("sign", "/v", "/sha1", $authenticodeThumbprintNormalized, "/fd", "SHA256")
+  if ($CertificateStore -eq "LocalMachine") {
+    $signArguments += "/sm"
+  }
+  if ($SignToolCsp) {
+    $signArguments += @("/csp", $SignToolCsp, "/kc", $SignToolKeyContainer)
+  }
+  if ($UseLegacyAuthenticodeTimestamp) {
+    $signArguments += @("/t", $TimestampUrl.AbsoluteUri)
+  } else {
+    $signArguments += @("/tr", $TimestampUrl.AbsoluteUri, "/td", "SHA256")
+  }
+  $signArguments += "%1"
+
+  $overlay = [ordered]@{
+    bundle = [ordered]@{
+      targets = @("nsis")
+      windows = [ordered]@{
+        signCommand = [ordered]@{
+          cmd = $signTool
+          args = $signArguments
+        }
+      }
+    }
+  }
+  $overlay | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $overlayPath -Encoding utf8NoBOM
+
+  $env:CARGO_TARGET_DIR = $targetDirectory
+  $env:CI = "true"
+  $buildStartedOn = (Get-Date).ToUniversalTime()
+
+  Invoke-External -FilePath $deno -ArgumentList @("install", "--frozen") `
+    -WorkingDirectory $repositoryRoot -Description "Installation verrouillee des dependances Deno"
+  Invoke-External -FilePath $deno -ArgumentList @("task", "typecheck") `
+    -WorkingDirectory $repositoryRoot -Description "Typecheck frontend"
+  Invoke-External -FilePath $deno -ArgumentList @("task", "lint") `
+    -WorkingDirectory $repositoryRoot -Description "Lint frontend"
+  Invoke-External -FilePath $deno -ArgumentList @("task", "test") `
+    -WorkingDirectory $repositoryRoot -Description "Tests unitaires frontend"
+  Invoke-External -FilePath $cargo -ArgumentList @("test", "--locked") `
+    -WorkingDirectory $tauriDirectory -Description "Tests Rust"
+  Invoke-External -FilePath $deno -ArgumentList @("task", "tauri", "build", "--ci", "--config", $overlayPath) `
+    -WorkingDirectory $repositoryRoot -Description "Build officiel Tauri NSIS signe"
+
+  $postBuildHead = (Get-ExternalOutput -FilePath $git -ArgumentList @("rev-parse", "HEAD") `
+    -WorkingDirectory $repositoryRoot -Description "Revalidation du commit apres build").ToLowerInvariant()
+  $postBuildStatus = Get-ExternalOutput -FilePath $git `
+    -ArgumentList @("status", "--porcelain=v1", "--untracked-files=all") `
+    -WorkingDirectory $repositoryRoot -Description "Revalidation de la proprete Git apres build"
+  if ($postBuildHead -ne $expectedCommitNormalized -or $postBuildStatus) {
+    throw "Le build a modifie ou remplace la source approuvee ; aucune provenance ne sera signee.`n$postBuildStatus"
+  }
+
+  $validatePeScript = Join-Path $repositoryRoot "script\ci\validate-windows-release-binary.ps1"
+  $validateBundleScript = Join-Path $repositoryRoot "script\ci\check-windows-bundles-no-npcap.ps1"
+  $releaseBinary = Join-Path $targetDirectory "release\sonar.exe"
+  if (-not (Test-Path -LiteralPath $releaseBinary -PathType Leaf)) {
+    throw "Executable Windows attendu introuvable : $releaseBinary"
+  }
+  Invoke-External -FilePath $pwsh -ArgumentList @("-NoProfile", "-File", $validatePeScript, "-BinaryPath", $releaseBinary) `
+    -WorkingDirectory $repositoryRoot -Description "Validation de la structure PE et des imports"
+  Invoke-External -FilePath $pwsh -ArgumentList @("-NoProfile", "-File", $validateBundleScript, "-TargetDirectory", $targetDirectory) `
+    -WorkingDirectory $repositoryRoot -Description "Validation du contenu NSIS"
+
+  $installers = @(Get-ChildItem -LiteralPath $targetDirectory -Recurse -File -Filter "*setup.exe" |
+    Where-Object { $_.FullName -match '[\\/]bundle[\\/]nsis[\\/]' })
+  if ($installers.Count -ne 1) {
+    throw "Un seul installateur NSIS etait attendu ; trouve : $($installers.Count)."
+  }
+  Assert-AuthenticodeSignature -Path $releaseBinary -ExpectedThumbprint $authenticodeThumbprintNormalized `
+    -SignToolPath $signTool -WorkingDirectory $repositoryRoot
+  Assert-AuthenticodeSignature -Path $installers[0].FullName -ExpectedThumbprint $authenticodeThumbprintNormalized `
+    -SignToolPath $signTool -WorkingDirectory $repositoryRoot
+
+  $artifactPath = Join-Path $artifactDirectory.FullName $installers[0].Name
+  Copy-Item -LiteralPath $installers[0].FullName -Destination $artifactPath
+  Assert-AuthenticodeSignature -Path $artifactPath -ExpectedThumbprint $authenticodeThumbprintNormalized `
+    -SignToolPath $signTool -WorkingDirectory $repositoryRoot
+
+  $artifactSha256 = Get-Sha256 -Path $artifactPath
+  $buildFinishedOn = (Get-Date).ToUniversalTime()
+  $predicatePath = Join-Path $provenanceDirectory.FullName "sonar-windows-nsis-provenance.slsa-v1.json"
+  $predicate = [ordered]@{
+    buildDefinition = [ordered]@{
+      buildType = "urn:sonar:build:tauri-windows-nsis:v1"
+      externalParameters = [ordered]@{
+        source = $SourceRepositoryUri
+        gitTag = $ReleaseTag
+        expectedCommit = $expectedCommitNormalized
+        platform = "windows-x86_64"
+        bundle = "nsis"
+      }
+      internalParameters = [ordered]@{
+        sourceTreeClean = $true
+        tagSignatureRequired = (-not $AllowUnsignedTag.IsPresent)
+        authenticodeCertificateThumbprint = $authenticodeThumbprintNormalized
+        authenticodeCertificateStore = $CertificateStore
+        authenticodeTimestampProtocol = if ($UseLegacyAuthenticodeTimestamp) { "Authenticode" } else { "RFC3161" }
+        script = "script/release/win_officiel_builder_hsm_prov.ps1"
+      }
+      resolvedDependencies = @(
+        [ordered]@{
+          uri = $SourceRepositoryUri
+          digest = [ordered]@{ gitCommit = $expectedCommitNormalized }
+        },
+        [ordered]@{
+          uri = "$SourceRepositoryUri#deno.lock"
+          digest = [ordered]@{ sha256 = Get-Sha256 -Path (Join-Path $repositoryRoot "deno.lock") }
+        },
+        [ordered]@{
+          uri = "$SourceRepositoryUri#src-tauri/Cargo.lock"
+          digest = [ordered]@{ sha256 = Get-Sha256 -Path (Join-Path $tauriDirectory "Cargo.lock") }
+        },
+        [ordered]@{
+          uri = "$SourceRepositoryUri#config/build-versions.env"
+          digest = [ordered]@{ sha256 = Get-Sha256 -Path $buildVersionsPath }
+        },
+        [ordered]@{
+          uri = "$SourceRepositoryUri#script/release/win_officiel_builder_hsm_prov.ps1"
+          digest = [ordered]@{ sha256 = Get-Sha256 -Path $scriptPath }
+        }
+      )
+    }
+    runDetails = [ordered]@{
+      builder = [ordered]@{
+        id = $BuilderId
+        version = [ordered]@{
+          deno = $actualVersions.deno
+          node = $actualVersions.node
+          rust = $actualVersions.rust
+          tauriCli = $actualVersions.tauri
+          cosign = $actualVersions.cosign
+          powershell = $PSVersionTable.PSVersion.ToString()
+          windows = [Environment]::OSVersion.VersionString
+        }
+      }
+      metadata = [ordered]@{
+        invocationId = "urn:uuid:$invocationId"
+        startedOn = $buildStartedOn.ToString("o")
+        finishedOn = $buildFinishedOn.ToString("o")
+      }
+    }
+  }
+  $predicate | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $predicatePath -Encoding utf8NoBOM
+
+  $artifactSignatureBundle = Join-Path $signatureDirectory.FullName ($installers[0].Name + ".sigstore.json")
+  $attestationBundle = Join-Path $provenanceDirectory.FullName ($installers[0].Name + ".provenance.sigstore.json")
+
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("sign-blob", "--yes", "--use-signing-config=false", "--new-bundle-format=true", "--bundle", $artifactSignatureBundle) +
+      $cosignSignerArguments + $cosignTimestampArguments + @($artifactPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Signature Cosign HSM de l'installateur"
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("attest-blob", "--yes", "--use-signing-config=false", "--new-bundle-format=true", "--predicate", $predicatePath,
+      "--type", "slsaprovenance1", "--bundle", $attestationBundle) + $cosignSignerArguments + $cosignTimestampArguments + @($artifactPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Attestation SLSA v1 Cosign HSM"
+
+  $kitPublicKey = Join-Path $trustDirectory.FullName "cosign-sonar.pub"
+  Copy-Item -LiteralPath $cosignPublicKeyPath -Destination $kitPublicKey
+  $timestampVerificationArguments = @()
+  if ($cosignTimestampChainPath) {
+    $kitTimestampChain = Join-Path $trustDirectory.FullName "cosign-tsa-chain.pem"
+    Copy-Item -LiteralPath $cosignTimestampChainPath -Destination $kitTimestampChain
+    $timestampVerificationArguments = @("--use-signed-timestamps", "--timestamp-certificate-chain", $kitTimestampChain)
+  }
+
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("verify-blob", "--private-infrastructure", "--key", $kitPublicKey, "--bundle", $artifactSignatureBundle) +
+      $timestampVerificationArguments + @($artifactPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Verification locale de la signature Cosign"
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("verify-blob-attestation", "--private-infrastructure", "--key", $kitPublicKey, "--bundle", $attestationBundle,
+      "--type", "slsaprovenance1") + $timestampVerificationArguments + @($artifactPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Verification locale de la provenance SLSA"
+
+  $metadataPath = Join-Path $outputPath "metadata.json"
+  $metadata = [ordered]@{
+    schemaVersion = 1
+    product = "SONAR"
+    version = $releaseVersion
+    artifact = [ordered]@{
+      path = "artifacts/$($installers[0].Name)"
+      sha256 = $artifactSha256
+      format = "NSIS"
+      architecture = "x86_64"
+    }
+    source = [ordered]@{
+      repository = $SourceRepositoryUri
+      tag = $ReleaseTag
+      commit = $expectedCommitNormalized
+      clean = $true
+    }
+    authenticode = [ordered]@{
+      certificateThumbprint = $authenticodeThumbprintNormalized
+      certificateSubject = $certificate.Subject
+      certificateIssuer = $certificate.Issuer
+      certificateSerialNumber = $certificate.SerialNumber
+      certificateNotAfter = $certificate.NotAfter.ToUniversalTime().ToString("o")
+      timestamped = $true
+    }
+    provenance = [ordered]@{
+      predicateType = "https://slsa.dev/provenance/v1"
+      builderId = $BuilderId
+      signingMode = if ($PSCmdlet.ParameterSetName -eq "SecurityKey") { "cosign-security-key" } else { "cosign-hsm-kms" }
+      publicKeySha256 = Get-Sha256 -Path $kitPublicKey
+      privateInfrastructure = $true
+    }
+    invocationId = "urn:uuid:$invocationId"
+  }
+  $metadata | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $metadataPath -Encoding utf8NoBOM
+
+  $verificationPath = Join-Path $outputPath "VERIFY.txt"
+  $timestampVerificationText = if ($cosignTimestampChainPath) {
+    ' --use-signed-timestamps --timestamp-certificate-chain "trust\cosign-tsa-chain.pem"'
+  } else {
+    ""
+  }
+  @"
+Verification depuis la racine du kit :
+
+1. Authentifier le manifeste avant de recalculer ses empreintes :
+   cosign verify-blob --private-infrastructure --key "trust\cosign-sonar.pub" --bundle "signatures\SHA256SUMS.sigstore.json"$timestampVerificationText "SHA256SUMS"
+2. Recalculer chaque empreinte listee dans SHA256SUMS.
+3. Verifier Authenticode :
+   signtool verify /pa /all /v /tw "artifacts\$($installers[0].Name)"
+4. Verifier la signature Cosign de l'installateur :
+   cosign verify-blob --private-infrastructure --key "trust\cosign-sonar.pub" --bundle "signatures\$($installers[0].Name).sigstore.json"$timestampVerificationText "artifacts\$($installers[0].Name)"
+5. Verifier la provenance SLSA et le digest du sujet :
+   cosign verify-blob-attestation --private-infrastructure --key "trust\cosign-sonar.pub" --bundle "provenance\$($installers[0].Name).provenance.sigstore.json" --type slsaprovenance1$timestampVerificationText "artifacts\$($installers[0].Name)"
+
+La cle publique doit etre comparee a une copie de confiance diffusee par un canal separe.
+"@ | Set-Content -LiteralPath $verificationPath -Encoding utf8NoBOM
+
+  $hashManifestPath = Join-Path $outputPath "SHA256SUMS"
+  $filesToHash = @(Get-ChildItem -LiteralPath $outputPath -Recurse -File |
+    Where-Object { $_.FullName -ne $hashManifestPath -and $_.FullName -ne $transcriptPath } |
+    Sort-Object FullName)
+  $hashLines = foreach ($file in $filesToHash) {
+    $relativePath = [IO.Path]::GetRelativePath($outputPath, $file.FullName).Replace('\', '/')
+    "$(Get-Sha256 -Path $file.FullName)  $relativePath"
+  }
+  $hashLines | Set-Content -LiteralPath $hashManifestPath -Encoding utf8NoBOM
+
+  $hashManifestSignatureBundle = Join-Path $signatureDirectory.FullName "SHA256SUMS.sigstore.json"
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("sign-blob", "--yes", "--use-signing-config=false", "--new-bundle-format=true", "--bundle", $hashManifestSignatureBundle) +
+      $cosignSignerArguments + $cosignTimestampArguments + @($hashManifestPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Signature Cosign HSM du manifeste SHA256"
+  Invoke-External -FilePath $cosign `
+    -ArgumentList (@("verify-blob", "--private-infrastructure", "--key", $kitPublicKey, "--bundle", $hashManifestSignatureBundle) +
+      $timestampVerificationArguments + @($hashManifestPath)) `
+    -WorkingDirectory $repositoryRoot -Description "Verification locale du manifeste SHA256"
+
+  $buildSucceeded = $true
+  Write-Host "Kit officiel cree et verifie : $outputPath" -ForegroundColor Green
+  Write-Host "SHA-256 installateur : $artifactSha256"
+}
+finally {
+  if ($null -eq $previousCargoTargetDirectory) {
+    Remove-Item Env:CARGO_TARGET_DIR -ErrorAction SilentlyContinue
+  } else {
+    $env:CARGO_TARGET_DIR = $previousCargoTargetDirectory
+  }
+  if ($null -eq $previousCi) {
+    Remove-Item Env:CI -ErrorAction SilentlyContinue
+  } else {
+    $env:CI = $previousCi
+  }
+  if ($transcriptStarted) {
+    Stop-Transcript | Out-Null
+  }
+  if (Test-Path -LiteralPath $workDirectory) {
+    Remove-Item -LiteralPath $workDirectory -Recurse -Force
+  }
+  if (-not $buildSucceeded) {
+    Write-Warning "Build officiel interrompu. Le kit partiel est conserve dans $outputPath."
+  }
+}

--- a/src/tests/windowsOfficialBuilder.test.ts
+++ b/src/tests/windowsOfficialBuilder.test.ts
@@ -1,0 +1,76 @@
+// Contrat statique du builder Windows officiel. Le build reel et les acces HSM
+// restent verifies sur le poste Windows de release.
+import {
+  equal as assertEquals,
+  match as assertMatch,
+  ok as assert,
+} from "node:assert/strict";
+import script from "../../script/release/win_officiel_builder_hsm_prov.ps1" with {
+  type: "text",
+};
+import documentation from "../../script/release/WIN_OFFICIEL_BUILDER_HSM_PROV.md" with {
+  type: "text",
+};
+
+Deno.test("builder Windows officiel - source et sortie verrouillees", () => {
+  assertMatch(script, /git\", \"tag\", \"-v\"|@\("tag", "-v", \$ReleaseTag\)/);
+  assert(
+    script.includes('"status", "--porcelain=v1", "--untracked-files=all"'),
+  );
+  assert(
+    script.includes("HEAD ($headCommit) ne correspond pas au commit approuve"),
+  );
+  assert(
+    script.includes("OutputDirectory doit etre situe hors du depot source"),
+  );
+  assert(script.includes("OutputDirectory existe deja et n'est pas vide"));
+});
+
+Deno.test("builder Windows officiel - Authenticode reste dans le HSM", () => {
+  assert(script.includes("signCommand = [ordered]@{"));
+  assert(script.includes('@("sign", "/v", "/sha1"'));
+  assert(script.includes('$signArguments += "/sm"'));
+  assert(
+    script.includes('@("/tr", $TimestampUrl.AbsoluteUri, "/td", "SHA256")'),
+  );
+  assert(script.includes('$signArguments += "%1"'));
+  assert(script.includes("TimeStamperCertificate"));
+  assertEquals(script.includes("--no-sign"), false);
+  assertEquals(script.includes("repro-env"), false);
+});
+
+Deno.test("builder Windows officiel - provenance SLSA signee et reverifiee", () => {
+  assert(script.includes('"--type", "slsaprovenance1"'));
+  assert(script.includes('"attest-blob"'));
+  assert(script.includes('"verify-blob-attestation"'));
+  assert(script.includes('"--private-infrastructure"'));
+  assert(script.includes('"--use-signing-config=false"'));
+  assert(script.includes("CosignKeyReference doit etre une reference HSM/KMS"));
+  assert(script.includes("Preflight de la cle Cosign HSM"));
+  assert(script.includes('"SHA256SUMS.sigstore.json"'));
+  assert(script.includes("publicKeySha256"));
+});
+
+Deno.test("builder Windows officiel - commande operateur documentee", () => {
+  for (
+    const parameter of [
+      "-ReleaseTag",
+      "-ExpectedCommit",
+      "-AuthenticodeThumbprint",
+      "-CertificateStore",
+      "-TimestampUrl",
+      "-CosignKeyReference",
+      "-CosignSecurityKey",
+      "-CosignPublicKey",
+      "-OutputDirectory",
+    ]
+  ) {
+    assert(
+      documentation.includes(parameter),
+      `${parameter} absent de la documentation`,
+    );
+  }
+  assert(documentation.includes("VERIFY.txt"));
+  assert(documentation.includes("SHA256SUMS.sigstore.json"));
+  assert(documentation.includes("Ne jamais le passer en paramètre"));
+});


### PR DESCRIPTION
## Résumé

- ajoute un builder PowerShell Windows pour produire uniquement l’installateur NSIS officiel ;
- signe l’exécutable et l’installateur avec Authenticode via le certificat exposé par le HSM ;
- génère et signe une provenance SLSA v1 et le manifeste SHA-256 avec Cosign via HSM/KMS ou clé matérielle ;
- vérifie le tag, le commit, la propreté Git, les versions d’outils et toutes les signatures avant de produire le kit ;
- ajoute un guide opérateur complet et un contrat de test statique.

## Pourquoi

SONAR doit pouvoir être compilé et signé sur un poste Windows sécurisé, potentiellement sans accès Internet, tout en attestant précisément la provenance du binaire livré sans imposer la reproductibilité du bundle NSIS.

## Impact

L’équipe de release dispose d’une commande unique qui échoue de manière fermée et produit un kit de vérification autonome. Les clés privées ne sont jamais exportées. Aucun changement n’est apporté au chemin de build CI existant.

## Vérifications

- `deno test --allow-env src/tests/windowsOfficialBuilder.test.ts`
- `deno task typecheck`
- `deno task lint`
- analyse syntaxique PowerShell via `System.Management.Automation.Language.Parser`
- `git diff --check`

Le test réel Authenticode/HSM devra être exécuté sur le poste Windows officiel équipé du middleware et des clés.