### PR TITLE
fix: frontend audit fixes — silent errors, a11y, graph reset/perf

### DIFF
--- a/.github/workflows/covecode.yml
+++ b/.github/workflows/covecode.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate frontend coverage
         run: |
-          deno test --coverage=coverage/frontend src/tests/*.test.js
+          deno test --coverage=coverage/frontend src/tests/*.test.ts
           deno coverage \
             --lcov \
             --include='^file:.*/src/' \

--- a/.github/workflows/covecode.yml
+++ b/.github/workflows/covecode.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate frontend coverage
         run: |
-          deno test --coverage=coverage/frontend src/tests/*.test.ts
+          deno test --allow-env --coverage=coverage/frontend src/tests/*.test.ts
           deno coverage \
             --lcov \
             --include='^file:.*/src/' \

--- a/analyses/01082026_claude-sonnet-5_frontend.md
+++ b/analyses/01082026_claude-sonnet-5_frontend.md
@@ -1,0 +1,139 @@
+# Analyse complète du frontend — 01/08/2026 (Claude Sonnet 5)
+
+Périmètre : `src/` (Vue 3 Composition/Options API + TypeScript + Pinia + Sigma.js/Graphology), hors `src/types/generated/*` (généré depuis Rust via ts-rs, non audité ligne à ligne). ~7 800 lignes hors fichiers générés/tests. Tous les fichiers listés ont été lus intégralement (pas de grep superficiel) ; les findings à sévérité haute ont été re-vérifiés manuellement (lecture directe + pour deux d'entre eux, exécution réelle via `deno test`).
+
+Repo propre sur `main`, aucun fichier modifié pendant l'analyse.
+
+## Méthode
+
+Revue en 5 lots parallèles (panneaux AnalyseView, graphe Sigma/Graphology, NavBar/status-bar, cœur store/erreurs/types/utils/router, tests+tooling), chacun avec instruction de ne remonter que des défauts vérifiés en lisant le code réel — plusieurs points d'une analyse précédente (23/07) ont été explicitement retestés et se sont révélés corrigés depuis (routes mortes, `Matrice.vue`, ancien test Jest — tous supprimés par le commit `415298c7`).
+
+---
+
+## Findings — sévérité haute
+
+### 1. `src/errors/capture.ts:70-71` — crash si l'erreur `capture` imbriquée n'est pas un objet
+```ts
+const captureKind = captureError.message as CaptureErrorKind;
+if ("kind" in captureKind) {   // lève TypeError si captureKind est null/string/undefined
+```
+Vérifié par exécution : `displayCaptureError({ kind: "capture", message: null })` lève `TypeError: Cannot use 'in' operator...`. La garde ajoutée pour #161 (ligne 44) protège l'enveloppe externe mais pas ce payload imbriqué — contrairement à `handleExportError`/`handleImportError`/`handleLabelerror` qui ont bien `typeof !== "object"`. `displayCaptureError` est `async` et beaucoup d'appelants ne l'attendent pas (`TopBar.vue:193,275,297`, `LabelsPanel.vue:169,189,...`) : l'exception devient une rejection non gérée, **aucun dialogue d'erreur ne s'affiche** à l'utilisateur en cas de dérive de contrat côté backend.
+**Correctif** : appliquer la même garde `typeof/null` à `captureKind` que celle utilisée dans `isImportCancellation` (ligne 197-203), qui est le bon modèle.
+
+### 2. `src/utils/labelImport.ts:22` — même défaut pour les erreurs de label
+```ts
+const labelError = error.message as LabelErrorKind;
+switch (labelError.kind) {   // lève si error.message est null
+```
+Vérifié par exécution : `classifyLabelImportError({ kind: "label", message: null })` lève `TypeError: Cannot read properties of null`. Appelé en synchrone depuis `ImportPanel.vue:453-475` (`catch (err) { this.showLabelFileIssues(err); }`) : si ça lève, le `finally` libère l'UI mais ni le dialogue de conflits ni un message de repli ne s'affichent — le panneau se libère silencieusement sans expliquer l'échec.
+
+### 3. `src/components/AnalyseView/NetworkGraphComponent.vue:333-338` — `resetGraph()` ne vide pas la queue d'updates
+```ts
+resetGraph() {
+  this.forceLayout?.kill()
+  this.graph?.clear()
+  this.clearNodeInfos()
+  this.unpinTunnelHighlight()
+}
+```
+`_queue` (alimentée par `onGraphUpdate`, vidée seulement dans `flushQueue()` à la ligne 498-506) n'est ni vidée ni son `requestAnimationFrame` annulé. Scénario vérifié dans le code : un `GraphUpdate` pousse dans `_queue` et programme un rAF ; si un `GraphSnapshot` arrive avant l'exécution de ce rAF (ex. ouverture d'un nouveau fichier juste après l'arrêt d'une capture), `loadFromGraphData` appelle `resetGraph()` puis recharge le nouveau snapshot — mais le rAF déjà programmé s'exécute ensuite et rejoue l'update périmé sur le graphe fraîchement chargé (nœud/arête qui n'appartient pas au nouveau relevé).
+**Correctif** : dans `resetGraph()`, vider `this._queue` et annuler `this._raf` s'il est programmé.
+
+### 4. `src/components/AnalyseView/panels/ArbitrationDialog.vue:83-102` — échec d'arbitrage jamais montré à l'utilisateur
+```ts
+} catch (err) {
+  error(`Erreur arbitrage: ${err}`);
+} finally {
+  this.resolving = false;
+}
+```
+Contrairement à toutes les autres mutations de labels de la codebase, aucun `message()`/`displayCaptureError` n'est appelé — `displayCaptureError` n'est même pas importé dans ce fichier. Si le backend refuse l'arbitrage (ex. clé supprimée entre-temps), le bouton se réactive et la boîte reste ouverte sans aucune indication d'échec ; l'utilisateur peut croire l'arbitrage appliqué en fermant la boîte.
+
+### 5. `src/components/AnalyseView/panels/ImportPanel.vue:503-517` — invokes d'arbitrage sans `try/catch`
+`onArbitrationResolved()` et `openArbitration()` appellent `get_label_rows`/`get_label_conflicts` sans filet, contrairement à `mounted()` (ligne 529-531) qui catch explicitement le même appel. Si le backend est en défaut au clic sur « Arbitrer les conflits », le dialogue ne s'ouvre jamais et rien n'indique pourquoi ; après un arbitrage réussi, un échec du refresh laisse la table de labels silencieusement périmée.
+
+### 6. `src/components/NavBar/TopBar.vue:119-152` — `export_logs` sans aucun filet d'erreur
+`withImportLock` fait seulement `try { await action() } finally { ... }`, sans `catch`. `export_logs()` lève volontairement en cas d'annulation de la boîte de sauvegarde (ligne 146) et ne catch pas non plus les échecs `invoke`. Contrairement à `SaveAsCsv`/`SaveLabels` qui ont chacun leur `try/catch` + `displayCaptureError`. Résultat : annulation de la boîte de dialogue ou échec d'écriture (disque plein, permission refusée) → rejection de promesse non gérée, `isImporting` bien remis à `false` (le verrou ne reste pas bloqué) mais **aucun message n'est montré** ; l'utilisateur croit l'export réussi.
+
+---
+
+## Findings — sévérité moyenne
+
+| # | Fichier:ligne | Problème | Scénario |
+|---|---|---|---|
+| 7 | `ImportPanel.vue:307-355` vs `:377-413` | Nettoyage incohérent après échec : `packetFiles` vidé inconditionnellement même en erreur, `matrixFiles` vidé seulement en succès | Import de 5 PCAP, le 3ᵉ échoue (link-type non supporté) → toute la sélection est perdue au lieu de ne retirer que le fichier fautif |
+| 8 | `ImportPanel.vue:463-464, 497, 508-509` | `filteredlabelRows = labelRows` sans repasser par `filterLabelRows(..., searchInput)` après import/clear/arbitrage | Champ de recherche affiche « router » mais la table montre soudain toutes les lignes après un réimport CSV |
+| 9 | `Filter.vue:239-241, 261-263, 270-272` | Échecs `set_filter` catchés en `console.error` brut (plugin-log même pas importé dans ce fichier) — régression de la convention introduite par 93db941d | Rejet backend de `set_filter` → clic « Appliquer » semble ne rien faire, rien dans les logs applicatifs |
+| 10 | `Filter.vue:198-212` | `canApply` dépend des erreurs du formulaire guidé même en mode aperçu BPF manuel | IP invalide saisie puis abandonnée + BPF manuel valide tapé → bouton Appliquer reste désactivé sans lien visible avec la saisie réelle |
+| 11 | `ConfigPanel.vue:16-66` | `<label>` n'englobe pas l'`<input>`, pas de `for`/`id` | Clic sur le texte du label ne focus pas le champ ; lecteur d'écran annonce un spinbutton sans nom |
+| 12 | `NetworkGraphComponent.vue:483-495` + `exportPng.ts:7-17` | `downloadPng()` sans `try/catch`, contrairement à `editNodeLabel()` qui catch et affiche l'erreur | Échec `writeFile` (disque plein) ou `toBlob` → aucun message, l'utilisateur croit l'export réussi |
+| 13 | `NetworkGraphComponent.vue:215-261` | `nodeReducer`/`edgeReducer` allouent `{ ...data }` à chaque frame de rendu, même sans interaction (FA2 tourne en continu par défaut, `forceEnabled: true`) | Sur un graphe de plusieurs milliers de nœuds issu d'un import PCAP volumineux, pression GC inutile en continu |
+| 14 | `graph/graphSync.ts` (`spawnAnchor`, `upsertNode`) | Recalcul O(n) du barycentre à chaque nouveau nœud → O(n²) cumulé sur une capture live longue | Capture accumulant des milliers d'hôtes : dégradation progressive perceptible |
+| 15 | `graph/graphSync.ts` (`updateNodeTrafficSize`) | Reparcourt toutes les arêtes du nœud à chaque upsert d'arête touchant ce nœud → O(degré²) cumulé | Nœud « hub » (passerelle, DNS très sollicité) en capture live : coût cumulé élevé |
+| 16 | `graph/forceLayout.ts:45-47` | `resume()` ne relance pas `inferSettings` — réglages FA2 potentiellement obsolètes si le graphe a grossi pendant la pause | Gravité désactivée sur petit graphe, capture continue en tâche de fond, réactivation sur graphe désormais grand → physique instable |
+| 17 | `graph/MatrixLabelsPanel.vue:31-38` | Échec `get_matrix_labels` catché en `console.error` puis affiché comme « aucun label » — indiscernable d'un succès vide | Backend indisponible/verrou empoisonné → l'utilisateur croit à tort qu'aucun label n'est appliqué |
+| 18 | `TopBar.vue:120-123, 205-208, 226-229, 282-284` | Verrous d'action busy (`isImporting`) : retour silencieux (`stop()`) ou juste un `info()` en log, jamais un message visible | Clic sur Arrêter/Réinitialiser pendant un import en cours → rien ne se passe visuellement, perçu comme un bug |
+| 19 | `status-bar/StatusBar.vue:156` | `console.error` au lieu de `@tauri-apps/plugin-log` (fichier n'importe même pas le plugin) — régression convention | Échec `set_filter` en clear devient introuvable en diagnostic support (release) |
+| 20 | `status-bar/Cpu.vue:30-53` | Assignation de `this.unlisten` dans le `.then()` de `listen()` (asynchrone) — si démonté avant résolution, le listener réel n'est jamais désinscrit | Montage/démontage rapide (hot-reload, changement de route) → listener `cpu_usage_update` fantôme actif indéfiniment |
+| 21 | `.github/workflows/covecode.yml:85` | `deno test --coverage=coverage/frontend src/tests/*.test.js` ne matche que `dateUtils.test.js` (seul `.test.js` du dossier) sur 21 fichiers de test | Le badge Codecov frontend ne reflète que 3 tests sur ~163 ; couverture store/graphe/erreurs IPC/CSP entièrement absente du rapport malgré des tests existants et verts en local |
+| 22 | Couverture composants Vue | Zéro test sur les 18 fichiers `.vue` (dont `ImportPanel.vue` 969 lignes, `NetworkGraphComponent.vue` 723 lignes) — seule la logique pure extraite (`graph/*.ts`, `panels/import/*.ts`) est testée | Angle mort déjà identifié en interne ; les régressions listées ci-dessus (ex. #7, #8, #12) ne sont pas détectables par la suite actuelle |
+
+---
+
+## Findings — sévérité basse
+
+- **Modales sans sémantique d'accessibilité** (pattern répété, à traiter globalement plutôt qu'au cas par cas) : `ImportPanel.vue`, `Filter.vue`, `ConfigPanel.vue`, `ConflictDialog.vue`, `graph/MatrixLabelsPanel.vue` — aucune n'a `role="dialog"`/`aria-modal`/fermeture Échap/piège de focus, contrairement à `LabelsPanel.vue` et à la gestion `Escape` de `NetworkGraphComponent.vue` (édition de label) qui montrent le pattern correct déjà en place ailleurs dans l'app.
+- `ImportPanel.vue:178,551-552` — `unsubs` déclaré et bouclé au démontage mais jamais alimenté : boucle de nettoyage no-op.
+- `ImportPanel.vue:72` — champ de recherche sans `aria-label`.
+- `ImportPanel.vue:311` — `convertPcap()` sans le garde `if (!this.isRunning)` présent dans `importMatrixFiles`/`importLabelFile` (inatteignable aujourd'hui car TopBar désactive déjà le bouton, mais incohérence latente).
+- `ConfigPanel.vue:26,39,52,65` — `min`/`max`/`step` décoratifs : les champs ne sont pas dans un `<form>`, validation HTML5 jamais déclenchée.
+- `ConfigPanel.vue:206-209` + `CustomSelector/interfaceSelector.vue:124-140` — course latente entre auto-sélection d'interface et chargement de la config persistée (fenêtre étroite, se corrige seule).
+- `LabelsPanel.vue:255` — `console.warn` au lieu de `plugin-log` (import déjà présent dans le fichier, incohérence ponctuelle).
+- `ConflictDialog.vue:23` — `<img>` d'avertissement sans `alt`.
+- `ConflictDialog.vue:256-269,285-310` — CSS mort dupliqué depuis `ImportPanel.vue`.
+- `NetworkGraphComponent.vue:211,316` — `zoomLevel` réassigné à chaque frame de caméra sans throttle (re-render Vue à chaque frame de zoom/pan).
+- `NetworkGraphComponent.vue:550-557` — bouton bascule gravité sans `aria-pressed`.
+- `NetworkGraphComponent.vue:174` — `new Graph(...)` non paramétré en generics → `any` implicite propagé dans `nodeInfo.ts`/`labelEdit.ts`/`tunnelHighlight.ts`/`graphSync.ts` sur des champs sensibles (`mac`, `ip`, `encapIds`, `total_bytes`).
+- `graph/tunnelHighlight.ts:15-38` — scan complet du graphe à chaque survol d'arête tunnel (perceptible sur graphe dense).
+- `BottomLong.vue:148-153` — branche `else` morte dans `beforeUnmount`.
+- `BottomLong.vue:73-75,137,148` — cast `(this as unknown as ComponentWithResetBus)` pour `$bus` alors que `types/global.d.ts` le déclare déjà et que `NetworkGraphComponent.vue` y accède directement sans cast — incohérence de style entre deux fichiers voisins.
+- `TopBar.vue:13,202-219` — bouton Réinitialiser non désactivé pendant une capture (`isRunning` non vérifié, seulement `isImporting`) ; le backend refuse proprement mais l'UX est incohérente avec les autres boutons.
+- `TopBar.vue:15` — `alt="Flux"` copié-collé sur le bouton Config (devrait décrire « Configuration »), identique à l'`alt` du bouton Démarrer → lecteurs d'écran ne distinguent pas les deux boutons.
+- `TopBar.vue` — aucun bouton emoji (`🛑🔄💾🏷️🗂️📄❎📒🔍`) n'a d'`aria-label` ; le `title` n'est utilisé comme nom accessible que si le contenu est vide, ce qui n'est pas le cas ici.
+- `TopBar.vue:80,67-69,301-303,310-312` — code mort résiduel du refactor #e0ce7da7 : `showMatrice` (data), `toggleView()`, `toggleConfig()`.
+- `status-bar/Cpu.vue:42,48` — `warn(msg, extraArg)`/`error(msg, extraArg)` : le plugin-log n'accepte pas de second argument libre, la valeur utile (erreur réelle, valeur CPU invalide) est silencieusement perdue.
+- `utils/bpf.ts:57-58` — `isIp`/`isCidr` acceptent des octets hors [0-255] (`999.999.999.999`) ; sans impact réel car le backend revalide à `start_capture` avec message affiché.
+- `store/capture.ts` — `CaptureStatus` retypé à la main (`status as {is_running, session_id}`) car non exporté par ts-rs ; un renommage côté Rust ne casserait pas la compilation TS, juste silencieusement `undefined` à l'exécution (risque atténué car `sessionId` est aussi mis à jour via l'event `started`).
+- `types/capture.ts:19` — réexport mort de `PacketFlow`, non utilisé ailleurs dans le frontend.
+- `eslint.config.js` — `@typescript-eslint/no-explicit-any` désactivé globalement (impact limité, `tsconfig` a `strict: true` qui bloque déjà le `any` implicite).
+- `src/tests/**` exclu à la fois du lint et du typecheck strict — écart de rigueur assumé mais réel entre code test et code prod.
+- `reproBuildPolicy.test.ts`, `windowsOfficialBuilder.test.ts` — tests par substring/regex sur du texte de script plutôt qu'exécution réelle (build Windows/HSM impossible en CI) ; compromis documenté mais donne une fausse confiance de couverture.
+- `utils/appExit.ts` (garde anti-double-clic fermeture) — aucun test malgré un pattern `mockIPC` directement réutilisable dans la suite existante.
+
+---
+
+## Points vérifiés sans anomalie (pour éviter de re-creuser)
+
+- Pas de `v-html`/`innerHTML` nulle part dans le périmètre — aucun vecteur XSS identifié, tous les labels utilisateur/PCAP passent par interpolation Vue échappée ou `canvas.fillText`.
+- `LabelsPanel.vue` : aucune mise à jour optimiste avant confirmation backend (`invoke` toujours avant mutation locale) — pattern correct, cohérent avec le fix #161.
+- `labelEdit.ts` : rollback défensif correct (vérifie `graph.hasNode` avant réapplication).
+- `LegendComponent.vue` : `aria-expanded`/`aria-controls`/`aria-label` corrects, listener `MediaQueryList` bien désabonné.
+- `BottomLong.vue` : debounce/plafonnement des lignes de log correct (`MAX_LOG_ROWS`, `flushTimer`), pas de souci perf.
+- `ChannelStatus.vue`, `Timer.vue`, `InterfaceStatus.vue` : cleanup listeners/`setInterval` correct, gestion d'erreur présente, pas de `any`/cast dangereux.
+- `store/capture.ts` : switch exhaustif sur `CaptureEvent` avec filet `logUnknownEvent(event: never)` bien conçu ; logique de filtrage par `sessionId`/`lastStoppedSessionId` correcte et testée (`captureStore.test.ts`).
+- `types/NetDevice.ts` correspond exactement au DTO Rust (`src-tauri/src/dto/mod.rs`), malgré l'absence de génération ts-rs pour ce type.
+- `router/*`, `App.vue`, `main.ts` : rien de significatif — plus de routes mortes (nettoyées par 415298c7).
+- `import/fileTypes.ts`, `importLifecycle.ts`, `importProgress.ts`, `labelSearch.ts` : petites fonctions pures correctes, pas de `any`, pas de cast dangereux.
+- `Filter.vue:239-241` (validation BPF) : le backend ne valide `set_filter` qu'à `start_capture` (message bien affiché là) — pas de "capture cassée silencieusement", juste l'incohérence de logging notée en #9.
+- `sonarcube.yml` (contrairement à `covecode.yml`) couvre bien `src/tests/` en entier.
+- Écarté après vérification backend : pas de risque de collision de clé d'arête `${source}__${target}__${label}` dans `graphStyle.ts` — `Node.id` est un compteur atomique numérique côté Rust, `Edge.label` un enum de protocole fixe, aucun des deux ne peut contenir `__`.
+
+---
+
+## Ordre de correction recommandé
+
+1. **Erreurs qui font disparaître le message utilisateur en silence** (haute, groupe cohérent) : #1, #2 (gardes défensives manquantes sur payloads imbriqués), #4, #5, #6 (invokes/dialogues sans filet) — c'est le thème dominant de cette revue : plusieurs endroits laissent l'utilisateur sans aucune indication qu'une opération a échoué, ce qui est particulièrement grave pour un outil dont la promesse repose sur la fidélité et la traçabilité du relevé.
+2. #3 (queue graphe non vidée au reset) — corruption visuelle silencieuse du graphe affiché, correctif d'une ligne.
+3. Régressions de convention logging (#9, #19, LabelsPanel:255) — faciles à corriger, cassent le diagnostic support en release.
+4. #21 (Codecov frontend quasi vide) — un badge trompeur ; corriger le glob est trivial (`src/tests/*.test.ts`) et redonnerait une mesure réelle immédiatement.
+5. Le reste (moyenne/basse) est du confort UX, de l'a11y et de la dette de performance sur de gros graphes — à prioriser selon la taille réelle des relevés traités en production.

--- a/src/components/AnalyseView/NetworkGraphComponent.vue
+++ b/src/components/AnalyseView/NetworkGraphComponent.vue
@@ -212,21 +212,32 @@ export default defineComponent({
     },
 
     // === Reducers Sigma (état de survol/sélection -> rendu) ================
+    // Sigma appelle ces reducers pour chaque nœud/arête à chaque frame (donc
+    // en continu tant que ForceAtlas2 tourne, par défaut activé) : un chemin
+    // rapide qui renvoie `data` tel quel sans le copier évite une allocation
+    // par élément et par frame quand rien ne doit être surchargé.
     nodeReducer(node: string, data: NodeRenderAttributes): NodeRenderAttributes {
-      const res: NodeRenderAttributes = { ...data }
       const tunnelNodes = this.hoveredTunnelNodes
-      if (tunnelNodes && !tunnelNodes.has(node)) {
+      const dimmed = !!tunnelNodes && !tunnelNodes.has(node)
+      const isHovered = node === this.hoveredNode
+      const isSelected = node === this.selectedNodeId
+      if (!dimmed && !isHovered && !isSelected) return data
+
+      const res: NodeRenderAttributes = { ...data }
+      if (dimmed) {
         res.color = DIM_NODE_COLOR
         res.label = null
       }
-      if (node === this.hoveredNode) res.color = data.hoverColor ?? res.color
-      if (node === this.selectedNodeId) res.highlighted = true
+      if (isHovered) res.color = data.hoverColor ?? res.color
+      if (isSelected) res.highlighted = true
       return res
     },
 
     edgeReducer(edge: string, data: EdgeRenderAttributes): EdgeRenderAttributes {
-      const res: EdgeRenderAttributes = { ...data }
       const tunnelEdges = this.hoveredTunnelEdges
+      if (!tunnelEdges && !this._edgeLabelsShown) return data
+
+      const res: EdgeRenderAttributes = { ...data }
       const dimmed = !!tunnelEdges && !tunnelEdges.has(edge)
       if (tunnelEdges) {
         if (dimmed) {
@@ -335,6 +346,14 @@ export default defineComponent({
       this.graph?.clear()
       this.clearNodeInfos()
       this.unpinTunnelHighlight()
+      // Vide les updates de capture live déjà en file : sans ça, un update
+      // mis en attente avant le reset peut être rejoué sur le graphe qui
+      // vient d'être rechargé (nouveau fichier/snapshot).
+      this._queue.length = 0
+      if (this._raf) {
+        cancelAnimationFrame(this._raf)
+        this._raf = 0
+      }
     },
 
     /**

--- a/src/components/AnalyseView/graph/MatrixLabelsPanel.vue
+++ b/src/components/AnalyseView/graph/MatrixLabelsPanel.vue
@@ -6,6 +6,7 @@
 <script lang="ts">
 import { defineComponent } from "vue"
 import { invoke } from "@tauri-apps/api/core"
+import { error } from "@tauri-apps/plugin-log"
 
 export default defineComponent({
   name: "MatrixLabelsPanel",
@@ -32,15 +33,23 @@ export default defineComponent({
     try {
       this.matrixLabels = await invoke<[string, string, string][]>("get_matrix_labels")
     } catch (e) {
-      console.error("Erreur get_matrix_labels:", e)
+      error(`Erreur get_matrix_labels: ${e}`)
       this.matrixLabels = []
     }
+    (this.$refs.search as HTMLInputElement | undefined)?.focus()
   },
 })
 </script>
 
 <template>
-  <div class="labels-overlay" @click.self="$emit('close')">
+  <div
+    class="labels-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Labels appliqués à la matrice"
+    @click.self="$emit('close')"
+    @keydown.esc="$emit('close')"
+  >
     <div class="labels-modal">
       <div class="labels-modal-header">
         <h3>Labels appliqués à la matrice ({{ matrixLabels.length }})</h3>
@@ -48,10 +57,12 @@ export default defineComponent({
       </div>
 
       <input
+        ref="search"
         v-model="search"
         class="labels-search"
         type="text"
         placeholder="Rechercher (MAC, IP, label)…"
+        aria-label="Rechercher un label"
       />
 
       <p v-if="matrixLabels.length === 0" class="labels-empty">

--- a/src/components/AnalyseView/graph/forceLayout.ts
+++ b/src/components/AnalyseView/graph/forceLayout.ts
@@ -39,16 +39,27 @@ export function createForceLayoutController(graph: Graph): ForceLayoutController
     layout.start()
   }
 
+  // Le graphe a assez grandi depuis le dernier inferSettings pour que
+  // slowDown/BarnesHut (dépendants de la taille) soient devenus obsolètes.
+  function outgrown() {
+    return !layout || lastOrder === 0 || graph.order >= lastOrder * 4
+  }
+
   return {
     start,
     stop() { layout?.stop() },
     resume() {
-      if (layout && lastOrder > 0) layout.start()
+      // Le graphe peut avoir grandi pendant que le layout était en pause
+      // (Gravité désactivée côté composant) : ensureSettings() n'est alors
+      // pas appelé (gardé par forceEnabled), donc resume() doit refaire le
+      // même contrôle plutôt que reprendre aveuglément des réglages
+      // potentiellement obsolètes pour la taille actuelle du graphe.
+      if (layout && !outgrown()) layout.start()
       else start()
     },
     ensureSettings() {
       if (graph.order === 0) return
-      if (!layout || lastOrder === 0 || graph.order >= lastOrder * 4) start()
+      if (outgrown()) start()
     },
     kill,
   }

--- a/src/components/AnalyseView/graph/graphSync.ts
+++ b/src/components/AnalyseView/graph/graphSync.ts
@@ -23,12 +23,23 @@ interface ParallelEdgeAttributes extends Record<string, unknown> {
   parallelMaxIndex?: number
 }
 
-/** Barycentre des nœuds existants (point d'apparition des nouveaux). */
+// Nombre de nœuds échantillonnés pour l'ancrage d'apparition : suffisant
+// pour retomber « raisonnablement près » du cluster existant (ForceAtlas2
+// corrige l'écart ensuite), sans coût O(n) par nouveau nœud — O(n²) cumulé
+// sur une capture longue avec beaucoup d'hôtes.
+const SPAWN_ANCHOR_SAMPLE_SIZE = 200
+
+/** Barycentre approché des nœuds existants (point d'apparition des nouveaux),
+ *  calculé sur un échantillon borné plutôt que sur tout le graphe. */
 export function spawnAnchor(graph: Graph): { x: number; y: number } {
   if (graph.order === 0) return { x: 0, y: 0 }
-  let sx = 0, sy = 0
-  graph.forEachNode((_n, attrs) => { sx += attrs.x; sy += attrs.y })
-  return { x: sx / graph.order, y: sy / graph.order }
+  let sx = 0, sy = 0, n = 0
+  graph.findNode((_node, attrs) => {
+    sx += attrs.x; sy += attrs.y
+    n += 1
+    return n >= SPAWN_ANCHOR_SAMPLE_SIZE
+  })
+  return { x: sx / n, y: sy / n }
 }
 
 /** Ajoute ou met à jour un nœud. Retourne true si un élément a été ajouté. */
@@ -45,11 +56,16 @@ export function upsertNode(graph: Graph, node: Node | null | undefined): boolean
   return true
 }
 
-/** Taille du nœud proportionnelle (log) au trafic cumulé de ses arêtes. */
-export function updateNodeTrafficSize(graph: Graph, nodeId: string) {
-  if (!graph.hasNode(nodeId)) return
-  let bytes = 0
-  graph.forEachEdge(nodeId, (_edge, attrs) => { bytes += attrs.total_bytes || 0 })
+/** Taille du nœud proportionnelle (log) au trafic cumulé de ses arêtes,
+ *  maintenue par delta (attribut interne `_trafficBytes`) plutôt que par un
+ *  rebalayage O(degré) de toutes les arêtes à chaque upsert — coûteux en
+ *  O(degré²) cumulé sur un nœud « hub » à fort degré. Sûr : les arêtes ne
+ *  sont jamais retirées individuellement (seul `graph.clear()` les efface,
+ *  ce qui efface aussi les nœuds et donc `_trafficBytes` avec eux). */
+function applyNodeTrafficDelta(graph: Graph, nodeId: string, deltaBytes: number) {
+  if (!graph.hasNode(nodeId) || deltaBytes === 0) return
+  const bytes = (Number(graph.getNodeAttribute(nodeId, "_trafficBytes")) || 0) + deltaBytes
+  graph.setNodeAttribute(nodeId, "_trafficBytes", bytes)
   graph.setNodeAttribute(nodeId, "size", nodeSizeFor(bytes))
 }
 
@@ -62,14 +78,18 @@ export function upsertEdge(graph: Graph, e: Edge | null | undefined): boolean {
   const key = edgeKey(e)
   const attrs = edgeAttributes(e)
   if (graph.hasEdge(key)) {
+    // Le backend envoie un compteur cumulé par arête : le delta face à
+    // l'ancienne valeur suffit à tenir la taille des nœuds à jour.
+    const previousBytes = Number(graph.getEdgeAttribute(key, "total_bytes")) || 0
     graph.mergeEdgeAttributes(key, attrs)
-    updateNodeTrafficSize(graph, e.source)
-    updateNodeTrafficSize(graph, e.target)
+    const delta = attrs.total_bytes - previousBytes
+    applyNodeTrafficDelta(graph, e.source, delta)
+    applyNodeTrafficDelta(graph, e.target, delta)
     return false
   }
   graph.addEdgeWithKey(key, e.source, e.target, attrs)
-  updateNodeTrafficSize(graph, e.source)
-  updateNodeTrafficSize(graph, e.target)
+  applyNodeTrafficDelta(graph, e.source, attrs.total_bytes)
+  applyNodeTrafficDelta(graph, e.target, attrs.total_bytes)
 
   // Un nœud fraîchement apparu est déplacé à côté de son premier voisin
   // déjà placé : ForceAtlas2 n'a plus qu'un ajustement local à faire.

--- a/src/components/AnalyseView/panels/ArbitrationDialog.vue
+++ b/src/components/AnalyseView/panels/ArbitrationDialog.vue
@@ -48,6 +48,7 @@
 import { defineComponent, PropType } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { info, error } from '@tauri-apps/plugin-log';
+import { displayCaptureError } from '../../../errors/capture';
 import { LabelConflictReport } from '../../../types/labels';
 
 type Candidate = { label: string; lines: number[] };
@@ -96,6 +97,7 @@ export default defineComponent({
         this.$emit('resolved');
       } catch (err) {
         error(`Erreur arbitrage: ${err}`);
+        await displayCaptureError(err);
       } finally {
         this.resolving = false;
       }

--- a/src/components/AnalyseView/panels/ConfigPanel.vue
+++ b/src/components/AnalyseView/panels/ConfigPanel.vue
@@ -4,17 +4,25 @@
   (commande config_capture).
 -->
 <template>
-  <div class="config-panel">
+  <div
+    class="config-panel"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Configuration Capture"
+    ref="panel"
+    tabindex="-1"
+    @keydown.esc="close"
+  >
     <h2>Configuration Capture</h2>
 
-    <InterfaceSelector 
+    <InterfaceSelector
       v-model="selectedInterface"
       :net-interfaces="netInterfaces"
       class="config-item"
     />
 
     <div class="config-item">
-      <label>
+      <label for="config-buffer-size">
         Taille du buffer :
         <span
           class="help-tooltip"
@@ -23,11 +31,11 @@
           data-tooltip="Buffer kernel pcap, en octets. Plus il est grand, plus SONAR absorbe les pics de trafic sans perte côté système."
         >?</span>
       </label>
-      <input type="number" v-model.number="bufferSize" min="65536" max="536870912" step="1024" />
+      <input id="config-buffer-size" type="number" v-model.number="bufferSize" min="65536" max="536870912" step="1024" />
     </div>
 
     <div class="config-item">
-      <label>
+      <label for="config-chan-capacity">
         Nombre de buffers:
         <span
           class="help-tooltip"
@@ -36,11 +44,11 @@
           data-tooltip="Capacité du canal interne entre capture et traitement. Trop petit, l'application peut perdre des paquets sous charge; trop grand, elle consomme plus de mémoire."
         >?</span>
       </label>
-      <input type="number" v-model.number="chanCapacity" min="1" max="1000000" />
+      <input id="config-chan-capacity" type="number" v-model.number="chanCapacity" min="1" max="1000000" />
     </div>
 
     <div class="config-item">
-      <label>
+      <label for="config-timeout">
         Timeout (ms) :
         <span
           class="help-tooltip"
@@ -49,11 +57,11 @@
           data-tooltip="Délai pcap avant livraison des paquets. Petit, il réduit la latence; plus grand, il favorise le batching."
         >?</span>
       </label>
-      <input type="number" v-model.number="timeout" min="1" max="10000" />
+      <input id="config-timeout" type="number" v-model.number="timeout" min="1" max="10000" />
     </div>
 
     <div class="config-item">
-      <label>
+      <label for="config-snaplen">
         Taille du snaplen :
         <span
           class="help-tooltip"
@@ -62,7 +70,7 @@
           data-tooltip="Nombre maximum d'octets capturés par paquet. Grand, il garde les paquets complets; petit, il réduit CPU et mémoire mais peut tronquer le décodage."
         >?</span>
       </label>
-      <input type="number" v-model.number="snaplen" min="64" max="262144" />
+      <input id="config-snaplen" type="number" v-model.number="snaplen" min="64" max="262144" />
     </div>
 
     <div class="actions">
@@ -206,6 +214,7 @@ export default defineComponent({
   mounted() {
     this.loadInterfaces();
     this.getConfig();
+    (this.$refs.panel as HTMLElement | undefined)?.focus();
   },
 
   watch: {

--- a/src/components/AnalyseView/panels/ConflictDialog.vue
+++ b/src/components/AnalyseView/panels/ConflictDialog.vue
@@ -4,8 +4,14 @@
   ligne par ligne remonté par le backend.
 -->
 <template>
-  <div class="container">
-    <div class="center-container">
+  <div
+    class="container"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Conflits d'import de labels"
+    @keydown.esc="windowClosed"
+  >
+    <div class="center-container" ref="panel" tabindex="-1">
 
       <h1 v-show="(same_ip_diff_mac.length > 0 || same_ip_diff_label.length > 0) && !resolved" class="dialog-title">Conflits détectés</h1>
       <h1 v-show="(same_ip_diff_mac.length > 0 || same_ip_diff_label.length > 0) && resolved" class="dialog-title">Conflits de labels résolus</h1>
@@ -20,7 +26,7 @@
 
       <div class="panels">
         <div class="left-panel">
-          <img class="image" src="../../../assets/images/warning-sign.png"/>
+          <img class="image" src="../../../assets/images/warning-sign.png" alt="Attention"/>
         </div>
         <div class="right-panel">
 
@@ -168,6 +174,10 @@ export default defineComponent({
     shownInvalidLines(): LineValue[] {
       return this.invalid_lines.slice(0, this.maxShown);
     },
+  },
+
+  mounted() {
+    (this.$refs.panel as HTMLElement | undefined)?.focus();
   },
 
   methods: {

--- a/src/components/AnalyseView/panels/CustomSelector/interfaceSelector.vue
+++ b/src/components/AnalyseView/panels/CustomSelector/interfaceSelector.vue
@@ -4,10 +4,11 @@
 -->
 <template>
   <div class="interface-selector">
-    <label class="selector-label">Interface réseau</label>
+    <label class="selector-label" for="interface-select">Interface réseau</label>
     <div class="selector-container">
-      <select 
-        v-model="selectedInterface" 
+      <select
+        id="interface-select"
+        v-model="selectedInterface"
         @change="onInterfaceChange"
         class="interface-select"
         :disabled="netInterfaces.length === 0"

--- a/src/components/AnalyseView/panels/Filter.vue
+++ b/src/components/AnalyseView/panels/Filter.vue
@@ -5,7 +5,16 @@
   utils/bpf.ts.
 -->
 <template>
-  <div class="filter-overlay" @click="$emit('update:visible', false)">
+  <div
+    class="filter-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Filtre BPF"
+    ref="panel"
+    tabindex="-1"
+    @click="$emit('update:visible', false)"
+    @keydown.esc="$emit('update:visible', false)"
+  >
     <div class="filter-panel" @click.stop>
 
       <!-- Header -->
@@ -80,24 +89,24 @@
         <div class="card">
           <h3>Adresses IP</h3>
           <div class="field">
-            <label>Inclure hôte</label>
-            <input v-model="ip.includeHost" placeholder="ex: 192.168.1.42" />
+            <label for="filter-ip-include-host">Inclure hôte</label>
+            <input id="filter-ip-include-host" v-model="ip.includeHost" placeholder="ex: 192.168.1.42" />
           </div>
           <div class="field">
-            <label>Exclure hôte</label>
-            <input v-model="ip.excludeHost" placeholder="ex: 10.0.0.1" />
+            <label for="filter-ip-exclude-host">Exclure hôte</label>
+            <input id="filter-ip-exclude-host" v-model="ip.excludeHost" placeholder="ex: 10.0.0.1" />
           </div>
           <div class="field">
-            <label>Inclure réseau</label>
-            <input v-model="ip.includeNet" placeholder="ex: 10.0.0.0/8" />
+            <label for="filter-ip-include-net">Inclure réseau</label>
+            <input id="filter-ip-include-net" v-model="ip.includeNet" placeholder="ex: 10.0.0.0/8" />
           </div>
           <div class="field">
-            <label>Exclure réseau</label>
-            <input v-model="ip.excludeNet" placeholder="ex: 192.168.0.0/16" />
+            <label for="filter-ip-exclude-net">Exclure réseau</label>
+            <input id="filter-ip-exclude-net" v-model="ip.excludeNet" placeholder="ex: 192.168.0.0/16" />
           </div>
           <div class="field">
-            <label>Direction</label>
-            <select v-model="ip.direction">
+            <label for="filter-ip-direction">Direction</label>
+            <select id="filter-ip-direction" v-model="ip.direction">
               <option value="any">src ou dst</option>
               <option value="src">src</option>
               <option value="dst">dst</option>
@@ -111,20 +120,20 @@
         <div class="card">
           <h3>Ports</h3>
           <div class="field">
-            <label>Inclure port(s)</label>
-            <input v-model="ports.include" placeholder="ex: 80,443,22" />
+            <label for="filter-port-include">Inclure port(s)</label>
+            <input id="filter-port-include" v-model="ports.include" placeholder="ex: 80,443,22" />
           </div>
           <div class="field">
-            <label>Exclure port(s)</label>
-            <input v-model="ports.exclude" placeholder="ex: 25,21" />
+            <label for="filter-port-exclude">Exclure port(s)</label>
+            <input id="filter-port-exclude" v-model="ports.exclude" placeholder="ex: 25,21" />
           </div>
           <div class="field">
-            <label>Plage</label>
-            <input v-model="ports.range" placeholder="ex: 10000-20000" />
+            <label for="filter-port-range">Plage</label>
+            <input id="filter-port-range" v-model="ports.range" placeholder="ex: 10000-20000" />
           </div>
           <div class="field">
-            <label>Direction</label>
-            <select v-model="ports.direction">
+            <label for="filter-port-direction">Direction</label>
+            <select id="filter-port-direction" v-model="ports.direction">
               <option value="any">src ou dst</option>
               <option value="src">src</option>
               <option value="dst">dst</option>
@@ -140,7 +149,7 @@
       <!-- BPF brut -->
       <section class="card">
         <h3>Expression BPF brute</h3>
-        <input class="raw-input" v-model="advancedRaw" placeholder="ex: tcp[13] & 0x02 != 0 and tcp[13] & 0x10 = 0" />
+        <input class="raw-input" v-model="advancedRaw" placeholder="ex: tcp[13] & 0x02 != 0 and tcp[13] & 0x10 = 0" aria-label="Expression BPF brute" />
         <p class="hint">Concaténé à la fin du filtre généré avec <code>and</code>.</p>
       </section>
 
@@ -155,6 +164,7 @@
           :value="previewText"
           @input="onPreviewInput"
           placeholder="Le filtre BPF généré apparaît ici…"
+          aria-label="Aperçu du filtre BPF généré"
           rows="3"
         />
         <div class="errors" v-if="globalErrors.length">
@@ -172,8 +182,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onMounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
+import { error } from '@tauri-apps/plugin-log';
 import { useCaptureStore } from '../../../store/capture';
 import {
   BPF_PRESETS,
@@ -185,6 +196,9 @@ import {
 
 const emit = defineEmits<{ 'update:visible': [value: boolean] }>();
 const captureStore = useCaptureStore();
+const panel = ref<HTMLDivElement | null>(null);
+
+onMounted(() => { panel.value?.focus(); });
 
 const initial = emptyBpfFormState();
 const opt = ref(initial.opt);
@@ -237,7 +251,7 @@ async function apply() {
     }
     emit('update:visible', false);
   } catch (e) {
-    console.error('set_filter failed:', e);
+    error(`set_filter failed: ${e}`);
   }
 }
 
@@ -259,7 +273,7 @@ async function resetAll() {
     captureStore.setActiveFilter('');
     captureStore.setPendingFilter('');
   } catch (e) {
-    console.error('clear filter failed:', e);
+    error(`clear filter failed: ${e}`);
   }
 }
 
@@ -268,7 +282,7 @@ async function cancelPending() {
     await invoke('set_filter', { filter: captureStore.activeFilter });
     captureStore.setPendingFilter('');
   } catch (e) {
-    console.error('cancel pending failed:', e);
+    error(`cancel pending failed: ${e}`);
   }
 }
 

--- a/src/components/AnalyseView/panels/ImportPanel.vue
+++ b/src/components/AnalyseView/panels/ImportPanel.vue
@@ -5,8 +5,14 @@
   Props : mode ('csv' | 'pcap'). Événement principal : update:visible.
 -->
 <template>
-  <div class="container">
-    <div class="center-container" :class="{ 'drag-over': isDragOver }">
+  <div
+    class="container"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="mode === 'csv' ? 'Import de labels' : 'Import de captures ou de matrices'"
+    @keydown.esc="closeOnEscape"
+  >
+    <div class="center-container" :class="{ 'drag-over': isDragOver }" ref="panel" tabindex="-1">
       <!-- Retour visuel de drag & drop -->
       <div class="drop-hint" v-if="isDragOver">
         <div class="drop-hint-inner">
@@ -69,7 +75,7 @@
           <div v-show="labelRows.length > 0" class="table-header-row">
             <h2 class="text table-title">Contenu importé</h2>
             <div class="search-group">
-              <input class="input-search" v-model="searchInput" @input="listFilter"/>
+              <input class="input-search" v-model="searchInput" @input="listFilter" aria-label="Rechercher dans les labels importés"/>
               <button class="btn image-btn icon-lg" @click.prevent="clearLabelStore()" title="Réinitialiser le contenu">🔄</button>
             </div>
           </div>
@@ -175,7 +181,6 @@ export default defineComponent({
       // sont courts et ne consultent pas le jeton backend).
       cancellableImport: false,
       cancelRequested: false,
-      unsubs: [] as Array<() => void>,
       showConflictDialog: false,
       conflictsResolved: false,
       showArbitration: false,
@@ -217,6 +222,13 @@ export default defineComponent({
   methods: {
     windowClosed() {
       this.$emit('update:visible', false);
+    },
+
+    // Échap ne ferme pas pendant une conversion en cours (même garde que le
+    // bouton ❌, désactivé via :disabled="isConverting").
+    closeOnEscape() {
+      if (this.isConverting) return;
+      this.windowClosed();
     },
 
     // Route les fichiers déposés (drag & drop) selon le mode du panneau et
@@ -461,7 +473,7 @@ export default defineComponent({
           },
           async () => {
             this.labelRows = await invoke('get_label_rows');
-            this.filteredlabelRows = this.labelRows;
+            this.filteredlabelRows = filterLabelRows(this.labelRows, this.searchInput);
           },
           displayCaptureError,
         );
@@ -494,7 +506,7 @@ export default defineComponent({
           await invoke('clear_label_store');
           info('réponse invoke');
           this.labelRows = await invoke('get_label_rows');
-          this.filteredlabelRows = this.labelRows;
+          this.filteredlabelRows = filterLabelRows(this.labelRows, this.searchInput);
         } catch (err) {
           displayCaptureError(err);
         }
@@ -504,21 +516,31 @@ export default defineComponent({
       this.showArbitration = false;
       this.arbitrationConflicts = [];
       this.pendingConflicts = 0;
-      // Rafraîchit la table de labels après arbitrage.
-      this.labelRows = await invoke('get_label_rows');
-      this.filteredlabelRows = this.labelRows;
+      try {
+        // Rafraîchit la table de labels après arbitrage.
+        this.labelRows = await invoke('get_label_rows');
+        this.filteredlabelRows = filterLabelRows(this.labelRows, this.searchInput);
+      } catch (err) {
+        await displayCaptureError(err);
+      }
     },
 
     async openArbitration() {
-      this.arbitrationConflicts = await invoke<LabelConflictReport[]>('get_label_conflicts');
-      if (this.arbitrationConflicts.length > 0) {
-        this.showArbitration = true;
+      try {
+        this.arbitrationConflicts = await invoke<LabelConflictReport[]>('get_label_conflicts');
+        if (this.arbitrationConflicts.length > 0) {
+          this.showArbitration = true;
+        }
+      } catch (err) {
+        await displayCaptureError(err);
       }
     },
 
   },
 
   mounted() {
+    (this.$refs.panel as HTMLElement | undefined)?.focus();
+
     // NB : les imports ne touchent plus à isRunning (réservé à la capture
     // live) — leur cycle de vie passe par isImporting. L'ancien couplage aux
     // événements Started/Finished laissait isRunning bloqué à vrai si la
@@ -548,9 +570,6 @@ export default defineComponent({
   },
 
   beforeUnmount() {
-    for (const unsub of this.unsubs) unsub();
-    this.unsubs = [];
-
     if (this.unlistenDrop) {
       this.unlistenDrop();
       this.unlistenDrop = null;

--- a/src/components/AnalyseView/panels/LabelsPanel.vue
+++ b/src/components/AnalyseView/panels/LabelsPanel.vue
@@ -111,7 +111,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { Channel, invoke } from '@tauri-apps/api/core';
-import { info, error } from '@tauri-apps/plugin-log';
+import { info, warn, error } from '@tauri-apps/plugin-log';
 import { ask, open, save } from '@tauri-apps/plugin-dialog';
 
 import ArbitrationDialog from './ArbitrationDialog.vue';
@@ -252,7 +252,7 @@ export default defineComponent({
         const onEvent = new Channel<CaptureEvent>();
         onEvent.onmessage = (msg) => {
           if (msg.event === 'started' && msg.data.protocolVersion !== EXPECTED_PROTOCOL_VERSION) {
-            console.warn(
+            warn(
               `[LabelsPanel] version du contrat IPC inattendue : reçu ${msg.data.protocolVersion}, attendu ${EXPECTED_PROTOCOL_VERSION}`
             );
           }

--- a/src/components/NavBar/TopBar.vue
+++ b/src/components/NavBar/TopBar.vue
@@ -5,26 +5,26 @@
 -->
 <template>
   <div class="top-bar">
-    <button class="image-btn" @click="start" title="Démarrer (ctrl+p)" :disabled="isRunning || activePanel !== null">
+    <button class="image-btn" @click="start" title="Démarrer (ctrl+p)" aria-label="Démarrer la capture" :disabled="isRunning || activePanel !== null">
       <img src="../../../src-tauri/icons/StoreLogo.png" alt="Flux" class="icon-img" />
     </button>
 
-    <button class="image-btn" @click="stop" title="Arrêter (ctrl+shift+p)" :disabled="!isRunning">🛑</button>
-    <button class="image-btn" @click="reset" :disabled="activePanel !== null" title="Réinitialiser (ctrl+shift+r)">🔄</button>
-    <button class="image-btn"  title="Config (ctrl+,)" :disabled="isRunning" @click="handleConfigClick">
-      <img src="../../assets/mdi--gear.svg" alt="Flux" class="icon-img" />
+    <button class="image-btn" @click="stop" title="Arrêter (ctrl+shift+p)" aria-label="Arrêter la capture" :disabled="!isRunning">🛑</button>
+    <button class="image-btn" @click="reset" :disabled="activePanel !== null" title="Réinitialiser (ctrl+shift+r)" aria-label="Réinitialiser">🔄</button>
+    <button class="image-btn" title="Config (ctrl+,)" aria-label="Configuration" :disabled="isRunning" @click="handleConfigClick">
+      <img src="../../assets/mdi--gear.svg" alt="Configuration" class="icon-img" />
     </button>
 
-    <button class="image-btn" @click="triggerSave" title="Sauvegarder (ctrl+s)">💾</button>
-    <button class="image-btn" @click="SaveLabels" title="Exporter les labels">🏷️</button>
-    <button class="image-btn" @click="handleLabelsClick" :disabled="isRunning" title="Gérer les labels">🗂️</button>
+    <button class="image-btn" @click="triggerSave" title="Sauvegarder (ctrl+s)" aria-label="Sauvegarder la matrice de flux">💾</button>
+    <button class="image-btn" @click="SaveLabels" title="Exporter les labels" aria-label="Exporter les labels">🏷️</button>
+    <button class="image-btn" @click="handleLabelsClick" :disabled="isRunning" title="Gérer les labels" aria-label="Gérer les labels">🗂️</button>
 
-    <button class="image-btn" @click="displayPcapOpener" :disabled="isRunning || captureStore.hasData" title="Ouvrir un fichier Pcap ou une matrice de flux (ctrl+o)">📄</button>
+    <button class="image-btn" @click="displayPcapOpener" :disabled="isRunning || captureStore.hasData" title="Ouvrir un fichier Pcap ou une matrice de flux (ctrl+o)" aria-label="Ouvrir un fichier Pcap ou une matrice de flux">📄</button>
     <button class="image-btn" @click="displayCsvOpener" :disabled="isRunning" title="Importer un fichier de label"><img src="../../assets/images/import_csv.png" alt="Importer un fichier de label" /></button>
-    
-    <button class="image-btn" @click="quit" title="Quitter (ctrl+q)">❎</button>
-    <button class="image-btn" @click="export_logs" title="Logs (ctrl+l)">📒</button>
-    <button class="image-btn" @click="handleFilterClick" :disabled="isRunning" title="Filtrer (ctrl+f)">🔍</button>
+
+    <button class="image-btn" @click="quit" title="Quitter (ctrl+q)" aria-label="Quitter">❎</button>
+    <button class="image-btn" @click="export_logs" title="Logs (ctrl+l)" aria-label="Exporter les logs">📒</button>
+    <button class="image-btn" @click="handleFilterClick" :disabled="isRunning" title="Filtrer (ctrl+f)" aria-label="Filtrer">🔍</button>
   </div>
 </template>
 
@@ -64,9 +64,6 @@ export default {
 },
 
   computed: {
-    buttonText(): string {
-      return this.captureStore.showMatrice ? 'Graphique' : 'Matrice';
-    },
     captureStore() {
       return useCaptureStore();
     },
@@ -77,7 +74,6 @@ export default {
   },
   data() {
     return {
-      showMatrice: true, // Toggle state (true for Matrice, false for NetworkGraphComponent)
       localHandler: null as ((e: KeyboardEvent) => void) | null,
       activePanel: null as Panel | null,
     };
@@ -135,19 +131,24 @@ export default {
     async export_logs() {
       info("export logs")
       await this.withImportLock(async () => {
-        const response = await save({
-          filters: [{ name: '.zip', extensions: ['zip'] }],
-          title: 'Sauvegarder les logs',
-          defaultPath: 'sonar-logs.zip'
-        });
+        try {
+          const response = await save({
+            filters: [{ name: '.zip', extensions: ['zip'] }],
+            title: 'Sauvegarder les logs',
+            defaultPath: 'sonar-logs.zip'
+          });
 
-        if (!response) {
-          info("Aucun chemin de fichier sélectionné");
-          throw new Error("Sauvegarde annulée ou chemin non sélectionné");
+          if (!response) {
+            info("Aucun chemin de fichier sélectionné");
+            return;
+          }
+          // Attendez que l'invocation d'API pour sauvegarder soit terminée
+          const saveResponse = await invoke('export_logs', { destination: response });
+          info(`Sauvegarde terminée: ${JSON.stringify(saveResponse)}`);
+        } catch (err) {
+          error(`Erreur export logs: ${err}`);
+          await displayCaptureError(err);
         }
-        // Attendez que l'invocation d'API pour sauvegarder soit terminée
-        const saveResponse = await invoke('export_logs', { destination: response });
-        info(`Sauvegarde terminée: ${JSON.stringify(saveResponse)}`);
       });
     },
 
@@ -298,18 +299,10 @@ export default {
         })
         .finally(() =>useCaptureStore().refreshHasData());
     },
-    toggleView() {
-      info('Vue basculée');
-    },
-
     async quit() {
       info('Fermeture demandée');
       await requestAppExit();
     },
-
-    toggleConfig() {
-      info('Ouverture panneau config'); 
-    }
   }
 }
 </script>

--- a/src/components/NavBar/status-bar/Cpu.vue
+++ b/src/components/NavBar/status-bar/Cpu.vue
@@ -39,13 +39,13 @@
         if (typeof cpu_usage === 'number') {
           this.cpuUsage = cpu_usage;
         } else {
-          warn('[CPU.vue] Invalid cpu_usage:', cpu_usage);
+          warn(`[CPU.vue] Invalid cpu_usage: ${cpu_usage}`);
         }
       }).then(unlisten => {
         this.unlisten = unlisten;
         info('[CPU.vue] Listener registered');
       }).catch(err => {
-        error('[CPU.vue] Failed to register listener', err);
+        error(`[CPU.vue] Failed to register listener: ${err}`);
       });
     },
     beforeUnmount() {

--- a/src/components/NavBar/status-bar/StatusBar.vue
+++ b/src/components/NavBar/status-bar/StatusBar.vue
@@ -73,6 +73,7 @@ import Cpu from './Cpu.vue';
 
 import { useCaptureStore } from '../../../store/capture';
 import { invoke } from '@tauri-apps/api/core';
+import { error } from '@tauri-apps/plugin-log';
 import type { Stats } from '../../../types/capture';
 
 type StatsView = Record<
@@ -153,7 +154,7 @@ export default defineComponent({
         await invoke('set_filter', { filter: '' });
         this.captureStore.setActiveFilter('');
       } catch (e) {
-        console.error('clear filter failed:', e);
+        error(`clear filter failed: ${e}`);
       }
     },
   },

--- a/src/errors/capture.ts
+++ b/src/errors/capture.ts
@@ -68,7 +68,9 @@ export async function displayCaptureError(err: unknown) {
         break;
       case "capture": {
         const captureKind = captureError.message as CaptureErrorKind;
-        if ("kind" in captureKind) {
+        // Même garde objet/null que ci-dessus (#161) : le payload imbriqué
+        // peut aussi être non conforme au contrat, pas seulement le premier niveau.
+        if (typeof captureKind === "object" && captureKind !== null && "kind" in captureKind) {
           switch (captureKind.kind) {
             case "invalidConfig":
               userFriendlyMessage =

--- a/src/tests/captureErrors.test.ts
+++ b/src/tests/captureErrors.test.ts
@@ -236,3 +236,17 @@ Deno.test("displayCaptureError - enveloppe du contrat : parcours nominal intact"
   );
   assertEquals(shown, ["Erreur Tauri : canal fermé"]);
 });
+
+Deno.test("displayCaptureError - payload capture imbriqué non conforme (null) : ne lève pas (régression)", async () => {
+  const shown = await withMockedDialog(() =>
+    displayCaptureError({ kind: "capture", message: null })
+  );
+  assertEquals(shown, ["Erreur inconnue"]);
+});
+
+Deno.test("displayCaptureError - payload capture imbriqué non conforme (chaîne) : ne lève pas (régression)", async () => {
+  const shown = await withMockedDialog(() =>
+    displayCaptureError({ kind: "capture", message: "panne" })
+  );
+  assertEquals(shown, ["Erreur inconnue"]);
+});

--- a/src/tests/labelImport.test.ts
+++ b/src/tests/labelImport.test.ts
@@ -54,3 +54,8 @@ Deno.test("classifyLabelImportError - sous-type de label inconnu -> null", () =>
   });
   assertEquals(result, null);
 });
+
+Deno.test("classifyLabelImportError - payload label imbriqué non conforme (null) -> null, ne lève pas (régression)", () => {
+  assertEquals(classifyLabelImportError({ kind: "label", message: null }), null);
+  assertEquals(classifyLabelImportError({ kind: "label", message: "boom" }), null);
+});

--- a/src/types/capture.ts
+++ b/src/types/capture.ts
@@ -16,7 +16,6 @@ export type { Node } from "./generated/Node";
 export type { Edge } from "./generated/Edge";
 export type { GraphUpdate } from "./generated/GraphUpdate";
 export type { GraphData } from "./generated/GraphData";
-export type { PacketFlow } from "./generated/PacketFlow";
 export type { DataLink } from "./generated/DataLink";
 export type { NetworkProtocol } from "./generated/NetworkProtocol";
 // Nom conservé côté frontend (le type Rust/généré s'appelle

--- a/src/utils/labelImport.ts
+++ b/src/utils/labelImport.ts
@@ -20,6 +20,13 @@ export function classifyLabelImportError(err: unknown): LabelFileIssues | null {
   if (!error || typeof error !== 'object' || error.kind !== 'label') return null;
 
   const labelError = error.message as LabelErrorKind;
+  // Garde objet/null (#161) : un payload `label` imbriqué non conforme au
+  // contrat (null/string) ne doit pas lever ici, juste retomber sur le
+  // fallback générique (`displayCaptureError`) plutôt que de planter en
+  // amont dans le catch synchrone du panneau d'import.
+  if (typeof labelError !== 'object' || labelError === null || !('kind' in labelError)) {
+    return null;
+  }
   switch (labelError.kind) {
     case 'invalidMacIpFormat': {
       const [invalidMac, invalidIp] = labelError.message;


### PR DESCRIPTION
## Summary
Fixes from a full frontend audit (`analyses/01082026_claude-sonnet-5_frontend.md`):

- **fix(errors)** — 6 high-severity findings: backend failures caught but never shown to the user (`errors/capture.ts`, `utils/labelImport.ts` nested payload guards; `ArbitrationDialog.vue`, `ImportPanel.vue`, `TopBar.vue` missing try/catch or unhandled rejection on cancel). Regression tests added.
- **fix(graph)** — `resetGraph()` didn't clear the pending live-capture update queue or cancel the scheduled animation frame, so a queued update could leak into a freshly loaded graph. `forceLayout.resume()` could reuse stale FA2 settings after growth while paused.
- **perf(graph)** — `spawnAnchor`/`updateNodeTrafficSize` were O(n²)/O(degree²) cumulative on long captures; now bounded sampling + delta tracking. Sigma reducers skip allocation when nothing needs overriding (called every frame while ForceAtlas2 runs).
- **fix(a11y)** — `role="dialog"`/`aria-modal`/Escape-close/focus added to `Filter`, `ConfigPanel`, `ConflictDialog`, `MatrixLabelsPanel` (matching the existing `LabelsPanel.vue` pattern). Fixes all 18 SonarCloud `Web:InputWithoutLabelCheck` bugs (label/id association or aria-label).
- **chore** — `console.*` → `plugin-log` regressions, dead code removal.
- **ci** — Codecov frontend glob only matched 1 of 21 test files.

## Test plan
- [x] `deno task typecheck` / `lint` / `test` (166 tests) all green
- [x] `deno task build` clean
- [x] Release Tauri build + `smoke-test-release-binary.sh` → `SONAR_STARTUP_VALIDATION=OK`
- [x] Manual sanity checks for the graphSync perf changes (500-node graph, hub traffic delta) — no regression vs full recompute
- [ ] Full X11 E2E harness not run (missing `xclip` in this environment, unrelated to the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)