### PR TITLE
fix: SonarCloud vulnerabilities and code smells (buttons, PRNG, nested literals)

### DIFF
--- a/src/components/AnalyseView/NetworkGraphComponent.vue
+++ b/src/components/AnalyseView/NetworkGraphComponent.vue
@@ -26,6 +26,7 @@ import {
   PORT_LABEL_ZOOM,
   drawNodeLabel,
   nodeAttributes,
+  randomFloat,
 } from "./graph/graphStyle"
 import {
   logUnknownGraphUpdateType,
@@ -388,8 +389,8 @@ export default defineComponent({
           const radius = 100 + Math.sqrt(n) * 40
           this.graph.addNode(id, {
             ...nodeAttributes({ ...node, id }),
-            x: Math.cos(angle) * radius + (Math.random() - 0.5) * 30,
-            y: Math.sin(angle) * radius + (Math.random() - 0.5) * 30,
+            x: Math.cos(angle) * radius + (randomFloat() - 0.5) * 30,
+            y: Math.sin(angle) * radius + (randomFloat() - 0.5) * 30,
           })
         }
 
@@ -565,8 +566,8 @@ export default defineComponent({
 <template>
   <div class="graph-container">
     <div class="top-buttons">
-      <button class="download-button" @click="downloadPng" title="Exporter en PNG">⬇️ Export PNG</button>
-      <button
+      <button type="button" class="download-button" @click="downloadPng" title="Exporter en PNG">⬇️ Export PNG</button>
+      <button type="button"
         class="force-button"
         :class="{ on: forceEnabled }"
         @click="toggleForce"
@@ -587,7 +588,7 @@ export default defineComponent({
         <div class="tunnel-info">🚇 {{ tunnelHoverInfo }}</div>
       </template>
       <div class="sep" />
-      <button class="download-button" @click="showLabelsPanel = true" title="afficher les labels">Afficher les labels</button>
+      <button type="button" class="download-button" @click="showLabelsPanel = true" title="afficher les labels">Afficher les labels</button>
       <div class="sep" />
       <div class="node-infos" v-if="selectedNodeInfos.length">
         <strong>Nœud sélectionné</strong>
@@ -602,7 +603,7 @@ export default defineComponent({
             placeholder="Entrer un label…"
             @keydown="onEditKeydown"
           />
-          <button
+          <button type="button"
             class="primary"
             :disabled="isSavingLabel || !selectedNode"
             @click="editNodeLabel"
@@ -610,7 +611,7 @@ export default defineComponent({
           >
             {{ isSavingLabel ? "Enregistrement…" : "Enregistrer" }}
           </button>
-          <button class="ghost" @click="cancelEdit" :disabled="isSavingLabel">Annuler</button>
+          <button type="button" class="ghost" @click="cancelEdit" :disabled="isSavingLabel">Annuler</button>
         </div>
 
         <ul>

--- a/src/components/AnalyseView/graph/MatrixLabelsPanel.vue
+++ b/src/components/AnalyseView/graph/MatrixLabelsPanel.vue
@@ -53,7 +53,7 @@ export default defineComponent({
     <div class="labels-modal">
       <div class="labels-modal-header">
         <h3>Labels appliqués à la matrice ({{ matrixLabels.length }})</h3>
-        <button class="labels-close" @click="$emit('close')" title="Fermer">✕</button>
+        <button type="button" class="labels-close" @click="$emit('close')" title="Fermer">✕</button>
       </div>
 
       <input

--- a/src/components/AnalyseView/graph/graphStyle.ts
+++ b/src/components/AnalyseView/graph/graphStyle.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeData, EdgeId, Node } from "../../../types/capture"
 import { colorForProtocol } from "../../../utils/protocolColors"
 
 // --- Couleurs ---------------------------------------------------------------
-function clamp01(x: number) { return x < 0 ? 0 : x > 1 ? 1 : x }
+function clamp01(x: number) { return Math.min(1, Math.max(0, x)) }
 
 function hexToRgb(hex: string) {
   const h = hex.startsWith("#") ? hex.slice(1) : hex
@@ -20,15 +20,15 @@ function rgbToHex(r: number, g: number, b: number) {
 
 export function darken(hex: string, factor = 0.2) {
   const { r, g, b } = hexToRgb(hex)
-  return rgbToHex((r * (1 - factor)) | 0, (g * (1 - factor)) | 0, (b * (1 - factor)) | 0)
+  return rgbToHex(Math.trunc(r * (1 - factor)), Math.trunc(g * (1 - factor)), Math.trunc(b * (1 - factor)))
 }
 
 export function brighten(hex: string, factor = 0.15) {
   const { r, g, b } = hexToRgb(hex)
   return rgbToHex(
-    (clamp01(r / 255 + factor) * 255) | 0,
-    (clamp01(g / 255 + factor) * 255) | 0,
-    (clamp01(b / 255 + factor) * 255) | 0
+    Math.trunc(clamp01(r / 255 + factor) * 255),
+    Math.trunc(clamp01(g / 255 + factor) * 255),
+    Math.trunc(clamp01(b / 255 + factor) * 255)
   )
 }
 
@@ -46,10 +46,17 @@ export function edgeKey(e: EdgeData): EdgeId {
 }
 
 // --- Positionnement ---------------------------------------------------------
+// CSPRNG plutôt que Math.random() : purement cosmétique ici (jitter de
+// positionnement des nœuds), mais évite le signalement générique de
+// SonarQube sur Math.random() (S2245, "PRNG non sécurisé").
+export function randomFloat(): number {
+  return crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32
+}
+
 // Jitter autour d'un point d'ancrage pour les nouveaux nœuds (évite l'empilement)
 export function jitterAround(x: number, y: number, radius = 120) {
-  const angle = Math.random() * 2 * Math.PI
-  const r = radius * (0.4 + 0.6 * Math.random())
+  const angle = randomFloat() * 2 * Math.PI
+  const r = radius * (0.4 + 0.6 * randomFloat())
   return { x: x + Math.cos(angle) * r, y: y + Math.sin(angle) * r }
 }
 

--- a/src/components/AnalyseView/panels/ArbitrationDialog.vue
+++ b/src/components/AnalyseView/panels/ArbitrationDialog.vue
@@ -7,7 +7,7 @@
 <template>
   <div class="container">
     <div class="center-container">
-      <button class="btn image-btn cross" @click.prevent="$emit('close')" :disabled="resolving">❌</button>
+      <button type="button" class="btn image-btn cross" @click.prevent="$emit('close')" :disabled="resolving">❌</button>
 
       <h1 class="dialog-title">Arbitrage des conflits de labels</h1>
       <p class="text subtitle">
@@ -35,8 +35,8 @@
       </div>
 
       <div class="actions">
-        <button class="btn btn-clear" @click="$emit('close')" :disabled="resolving">Fermer</button>
-        <button class="btn btn-open" @click="applyAll" :disabled="resolving">
+        <button type="button" class="btn btn-clear" @click="$emit('close')" :disabled="resolving">Fermer</button>
+        <button type="button" class="btn btn-open" @click="applyAll" :disabled="resolving">
           {{ resolving ? 'Application…' : 'Appliquer' }}
         </button>
       </div>

--- a/src/components/AnalyseView/panels/ConfigPanel.vue
+++ b/src/components/AnalyseView/panels/ConfigPanel.vue
@@ -24,12 +24,12 @@
     <div class="config-item">
       <label for="config-buffer-size">
         Taille du buffer :
-        <span
+        <button
+          type="button"
           class="help-tooltip"
-          tabindex="0"
           aria-label="Taille du buffer kernel pcap, en octets. Plus il est grand, plus SONAR absorbe les pics de trafic sans perte côté système."
           data-tooltip="Buffer kernel pcap, en octets. Plus il est grand, plus SONAR absorbe les pics de trafic sans perte côté système."
-        >?</span>
+        >?</button>
       </label>
       <input id="config-buffer-size" type="number" v-model.number="bufferSize" min="65536" max="536870912" step="1024" />
     </div>
@@ -37,12 +37,12 @@
     <div class="config-item">
       <label for="config-chan-capacity">
         Nombre de buffers:
-        <span
+        <button
+          type="button"
           class="help-tooltip"
-          tabindex="0"
           aria-label="Capacité du canal interne entre capture et traitement. Trop petit, l'application peut perdre des paquets sous charge; trop grand, elle consomme plus de mémoire."
           data-tooltip="Capacité du canal interne entre capture et traitement. Trop petit, l'application peut perdre des paquets sous charge; trop grand, elle consomme plus de mémoire."
-        >?</span>
+        >?</button>
       </label>
       <input id="config-chan-capacity" type="number" v-model.number="chanCapacity" min="1" max="1000000" />
     </div>
@@ -50,12 +50,12 @@
     <div class="config-item">
       <label for="config-timeout">
         Timeout (ms) :
-        <span
+        <button
+          type="button"
           class="help-tooltip"
-          tabindex="0"
           aria-label="Délai pcap avant livraison des paquets. Petit, il réduit la latence; plus grand, il favorise le batching."
           data-tooltip="Délai pcap avant livraison des paquets. Petit, il réduit la latence; plus grand, il favorise le batching."
-        >?</span>
+        >?</button>
       </label>
       <input id="config-timeout" type="number" v-model.number="timeout" min="1" max="10000" />
     </div>
@@ -63,19 +63,19 @@
     <div class="config-item">
       <label for="config-snaplen">
         Taille du snaplen :
-        <span
+        <button
+          type="button"
           class="help-tooltip"
-          tabindex="0"
           aria-label="Nombre maximum d'octets capturés par paquet. Grand, il garde les paquets complets; petit, il réduit CPU et mémoire mais peut tronquer le décodage."
           data-tooltip="Nombre maximum d'octets capturés par paquet. Grand, il garde les paquets complets; petit, il réduit CPU et mémoire mais peut tronquer le décodage."
-        >?</span>
+        >?</button>
       </label>
       <input id="config-snaplen" type="number" v-model.number="snaplen" min="64" max="262144" />
     </div>
 
     <div class="actions">
-      <button @click="save" :disabled="!selectedInterface">Sauvegarder</button>
-      <button @click="close">Fermer</button>
+      <button type="button" @click="save" :disabled="!selectedInterface">Sauvegarder</button>
+      <button type="button" @click="close">Fermer</button>
     </div>
   </div>
 </template>
@@ -279,10 +279,12 @@ export default defineComponent({
   justify-content: center;
   width: 18px;
   height: 18px;
+  padding: 0;
   border: 1px solid #8a8a8a;
   border-radius: 50%;
   color: #ffffff;
   background-color: #303744;
+  font-family: inherit;
   font-size: 12px;
   line-height: 1;
   cursor: help;

--- a/src/components/AnalyseView/panels/ConflictDialog.vue
+++ b/src/components/AnalyseView/panels/ConflictDialog.vue
@@ -34,25 +34,25 @@
               <ul v-show="same_ip_diff_mac.length > 0">
                 <h3 class="text">Conflits IP -> MAC</h3>
                 <li v-for="([lineA, lineB, ip, ref_mac, mac, rowA, rowB], index) in same_ip_diff_mac" :key="index">
-                  <label>
+                  <div class="conflict-entry">
                     <span class="text">'{{ ip }}'(IP) — lignes {{ lineA }} / {{ lineB }}:</span><br>
                     <span class="text indented">ligne {{ lineA }} MAC: '{{ ref_mac || "-" }}'</span>
                     <span class="text indented line-context">ligne {{ lineA }} complète : '{{ rowA }}'</span>
                     <span class="text indented">ligne {{ lineB }} MAC: '{{ mac || "-" }}'</span>
                     <span class="text indented line-context">ligne {{ lineB }} complète : '{{ rowB }}'</span>
-                  </label>
+                  </div>
                 </li>
               </ul>
               <ul v-show="same_ip_diff_label.length > 0">
                 <h3 class="text">Conflits IP -> Label</h3>
                 <li v-for="([lineA, lineB, ip, ref_label, label, rowA, rowB], index) in same_ip_diff_label" :key="index">
-                  <label>
+                  <div class="conflict-entry">
                     <span class="text">'{{ ip }}'(IP) — lignes {{ lineA }} / {{ lineB }}:</span><br>
                     <span class="text indented">ligne {{ lineA }} Label: '{{ ref_label || "-" }}'</span>
                     <span class="text indented line-context">ligne {{ lineA }} complète : '{{ rowA }}'</span>
                     <span class="text indented">ligne {{ lineB }} Label: '{{ label || "-" }}'</span>
                     <span class="text indented line-context">ligne {{ lineB }} complète : '{{ rowB }}'</span>
-                  </label>
+                  </div>
                 </li>
               </ul>
           </div>
@@ -61,10 +61,10 @@
               <ul v-show="invalid_mac.length > 0">
                 <h3 class="text">MAC invalides</h3>
                 <li v-for="([line, mac, row], index) in shownInvalidMac" :key="index">
-                  <label>
+                  <div class="conflict-entry">
                     <span class="text indented">ligne {{ line }} — MAC: '{{ mac }}'</span>
                     <span class="text indented line-context">ligne complète : '{{ row }}'</span>
-                  </label>
+                  </div>
                 </li>
                 <li v-if="invalid_mac.length > maxShown" class="text indented truncated">
                   … et {{ invalid_mac.length - maxShown }} autre{{ invalid_mac.length - maxShown > 1 ? 's' : '' }} (corrigez les premières : souvent la même cause)
@@ -73,10 +73,10 @@
               <ul v-show="invalid_ip.length > 0">
                 <h3 class="text">IP invalides</h3>
                 <li v-for="([line, ip, row], index) in shownInvalidIp" :key="index">
-                  <label>
+                  <div class="conflict-entry">
                     <span class="text indented">ligne {{ line }} — IP: '{{ ip }}'</span>
                     <span class="text indented line-context">ligne complète : '{{ row }}'</span>
-                  </label>
+                  </div>
                 </li>
                 <li v-if="invalid_ip.length > maxShown" class="text indented truncated">
                   … et {{ invalid_ip.length - maxShown }} autre{{ invalid_ip.length - maxShown > 1 ? 's' : '' }} (corrigez les premières : souvent la même cause)
@@ -87,9 +87,9 @@
             <ul>
               <h3 class="text">Lignes concernées :</h3>
               <li v-for="([line, value], index) in shownInvalidLines" :key="index">
-                <label>
+                <div class="conflict-entry">
                   <span class="text indented">ligne {{ line }} : '{{ value }}'</span>
-                </label>
+                </div>
               </li>
               <li v-if="invalid_lines.length > maxShown" class="text indented truncated">
                 … et {{ invalid_lines.length - maxShown }} autre{{ invalid_lines.length - maxShown > 1 ? 's' : '' }}
@@ -101,7 +101,7 @@
       </div>
 
       <div>
-          <button class="btn image-btn" @click.prevent="windowClosed">❌</button>
+          <button type="button" class="btn image-btn" @click.prevent="windowClosed">❌</button>
       </div>
      
     </div>
@@ -350,7 +350,7 @@ export default defineComponent({
   margin-right: auto;
 }
 
-.file-list label {
+.file-list .conflict-entry {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/components/AnalyseView/panels/Filter.vue
+++ b/src/components/AnalyseView/panels/Filter.vue
@@ -20,33 +20,33 @@
       <!-- Header -->
       <div class="panel-header">
         <h2>Filtre BPF</h2>
-        <button class="close-btn" @click="$emit('update:visible', false)">✕</button>
+        <button type="button" class="close-btn" @click="$emit('update:visible', false)">✕</button>
       </div>
 
       <!-- Filtre actif -->
       <div class="active-filter-bar" v-if="captureStore.activeFilter">
         <span class="active-filter-label">Filtre actif</span>
         <code class="active-filter-expr">{{ captureStore.activeFilter }}</code>
-        <button class="btn ghost active-filter-clear" @click="resetAll">Supprimer</button>
+        <button type="button" class="btn ghost active-filter-clear" @click="resetAll">Supprimer</button>
       </div>
 
       <!-- Filtre en attente (appliqué au prochain démarrage) -->
       <div class="pending-filter-bar" v-if="captureStore.pendingFilter">
         <span class="pending-filter-label">Prochain démarrage</span>
         <code class="active-filter-expr">{{ captureStore.pendingFilter }}</code>
-        <button class="btn ghost active-filter-clear" @click="cancelPending">Annuler</button>
+        <button type="button" class="btn ghost active-filter-clear" @click="cancelPending">Annuler</button>
       </div>
 
       <!-- Presets rapides -->
       <section class="card">
         <h3>Presets rapides</h3>
         <div class="chips">
-          <button class="chip" @click="preset('ipv4')">IPv4 only</button>
-          <button class="chip" @click="preset('web')">Web (80/443)</button>
-          <button class="chip" @click="preset('dns')">DNS (53)</button>
-          <button class="chip" @click="preset('ntp')">NTP (123)</button>
-          <button class="chip" @click="preset('syn')">TCP SYN only</button>
-          <button class="chip" @click="preset('no-arp-ipv6')">Tout sauf ARP/IPv6</button>
+          <button type="button" class="chip" @click="preset('ipv4')">IPv4 only</button>
+          <button type="button" class="chip" @click="preset('web')">Web (80/443)</button>
+          <button type="button" class="chip" @click="preset('dns')">DNS (53)</button>
+          <button type="button" class="chip" @click="preset('ntp')">NTP (123)</button>
+          <button type="button" class="chip" @click="preset('syn')">TCP SYN only</button>
+          <button type="button" class="chip" @click="preset('no-arp-ipv6')">Tout sauf ARP/IPv6</button>
         </div>
       </section>
 
@@ -171,9 +171,9 @@
           <span v-for="e in globalErrors" :key="e">• {{ e }}</span>
         </div>
         <div class="actions">
-          <button class="btn primary" @click="apply" :disabled="!canApply">Appliquer</button>
-          <button class="btn ghost" @click="resetAll">Réinitialiser</button>
-          <button class="btn ghost sync" v-if="isManualPreview" @click="syncPreview">↺ Sync auto</button>
+          <button type="button" class="btn primary" @click="apply" :disabled="!canApply">Appliquer</button>
+          <button type="button" class="btn ghost" @click="resetAll">Réinitialiser</button>
+          <button type="button" class="btn ghost sync" v-if="isManualPreview" @click="syncPreview">↺ Sync auto</button>
         </div>
       </section>
 

--- a/src/components/AnalyseView/panels/ImportPanel.vue
+++ b/src/components/AnalyseView/panels/ImportPanel.vue
@@ -52,23 +52,22 @@
             {{ importProgress.current.toLocaleString() }}/{{ importProgress.total.toLocaleString() }}
           </p>
         </div>
-        <button
+        <button type="button"
           v-if="cancellableImport"
           class="btn btn-cancel-import"
           @click="cancelImport"
           :disabled="cancelRequested"
-          aria-label="Annuler l'import en cours"
         >
           {{ cancelRequested ? 'Annulation…' : "Annuler l'import" }}
         </button>
       </div>
-      <button class="btn image-btn cross" @click.prevent="windowClosed" :disabled="isConverting">❌</button>
+      <button type="button" class="btn image-btn cross" @click.prevent="windowClosed" :disabled="isConverting">❌</button>
       
       <div v-if="mode === 'csv'" class="csv-group">
-          <button class="btn btn-add text" @click="addCsvFiles" :disabled="isConverting">
+          <button type="button" class="btn btn-add text" @click="addCsvFiles" :disabled="isConverting">
             Ajouter un fichier
           </button>
-          <button v-if="pendingConflicts > 0" class="btn btn-arbitrate" @click="openArbitration" :disabled="isConverting">
+          <button type="button" v-if="pendingConflicts > 0" class="btn btn-arbitrate" @click="openArbitration" :disabled="isConverting">
             ⚖️ Arbitrer les conflits ({{ pendingConflicts }})
           </button>
           <p v-show="labelRows.length == 0" class="text">Aucun label importé pour le moment</p>
@@ -76,7 +75,7 @@
             <h2 class="text table-title">Contenu importé</h2>
             <div class="search-group">
               <input class="input-search" v-model="searchInput" @input="listFilter" aria-label="Rechercher dans les labels importés"/>
-              <button class="btn image-btn icon-lg" @click.prevent="clearLabelStore()" title="Réinitialiser le contenu">🔄</button>
+              <button type="button" class="btn image-btn icon-lg" @click.prevent="clearLabelStore()" title="Réinitialiser le contenu">🔄</button>
             </div>
           </div>
           <div v-show="labelRows.length > 0" class="data-table">
@@ -99,10 +98,10 @@
       
       <div v-else-if="mode === 'pcap'">
         <div class="file-group">
-          <button class="btn btn-add text" @click="addPcapFiles" :disabled="isConverting">
+          <button type="button" class="btn btn-add text" @click="addPcapFiles" :disabled="isConverting">
             Ajouter des fichiers .pcap
           </button>
-          <button v-if="packetFiles.length > 0" class="btn btn-clear" @click="clearFiles" :disabled="isConverting">
+          <button type="button" v-if="packetFiles.length > 0" class="btn btn-clear" @click="clearFiles" :disabled="isConverting">
             Effacer
           </button>
         </div>
@@ -111,15 +110,15 @@
             {{ file }}
           </li>
         </ul>
-        <button v-if="packetFiles.length > 0" @click="convertPcap" class="btn btn-open" :disabled="isConverting">
+        <button type="button" v-if="packetFiles.length > 0" @click="convertPcap" class="btn btn-open" :disabled="isConverting">
           Ouvrir
         </button>
         <div class="separator matrix-separator"></div>
         <div class="file-group">
-          <button class="btn btn-add text" @click="addMatrixFiles" :disabled="isConverting">
+          <button type="button" class="btn btn-add text" @click="addMatrixFiles" :disabled="isConverting">
             Ajouter une ou plusieurs matrices (CSV ou XLSX)
           </button>
-          <button v-if="matrixFiles.length > 0" class="btn btn-clear" @click="clearMatrixFiles" :disabled="isConverting">
+          <button type="button" v-if="matrixFiles.length > 0" class="btn btn-clear" @click="clearMatrixFiles" :disabled="isConverting">
             Effacer
           </button>
         </div>
@@ -128,7 +127,7 @@
             {{ file }}
           </li>
         </ul>
-        <button v-if="matrixFiles.length > 0" @click="importMatrixFiles" class="btn btn-open" :disabled="isConverting">
+        <button type="button" v-if="matrixFiles.length > 0" @click="importMatrixFiles" class="btn btn-open" :disabled="isConverting">
           Ouvrir
         </button>
       </div>
@@ -276,9 +275,12 @@ export default defineComponent({
     },
 
     async addFiles(type: 'pcap' | 'csv' | 'matrix', extensions: string[]) {
-        const label = type === 'csv' ? 'Label File'
-          : type === 'matrix' ? 'Matrice CSV ou XLSX'
-          : 'Capture File';
+        const labels: Record<'pcap' | 'csv' | 'matrix', string> = {
+          csv: 'Label File',
+          matrix: 'Matrice CSV ou XLSX',
+          pcap: 'Capture File',
+        };
+        const label = labels[type];
         useCaptureStore().isImporting = true;
 
       try {

--- a/src/components/AnalyseView/panels/LabelsPanel.vue
+++ b/src/components/AnalyseView/panels/LabelsPanel.vue
@@ -14,7 +14,7 @@
     @keydown.esc="close"
   >
     <div class="center-container" ref="panel" tabindex="-1">
-      <button class="btn image-btn cross" @click.prevent="close" title="Fermer (Échap)">❌</button>
+      <button type="button" class="btn image-btn cross" @click.prevent="close" title="Fermer (Échap)">❌</button>
 
       <h1 class="dialog-title">Gestion des labels</h1>
       <p class="text subtitle">
@@ -32,15 +32,15 @@
           placeholder="Rechercher (MAC, IP, label)…"
           aria-label="Rechercher un label"
         />
-        <button
+        <button type="button"
           v-if="conflicts.length > 0"
           class="btn btn-conflicts"
           @click="showArbitration = true"
         >
           ⚖️ Arbitrer {{ conflicts.length }} conflit(s)
         </button>
-        <button class="btn" @click="importFile" :disabled="busy">📥 Importer</button>
-        <button class="btn" @click="exportFile" :disabled="busy || rows.length === 0">💾 Exporter</button>
+        <button type="button" class="btn" @click="importFile" :disabled="busy">📥 Importer</button>
+        <button type="button" class="btn" @click="exportFile" :disabled="busy || rows.length === 0">💾 Exporter</button>
       </div>
 
       <!-- Ajout d'une ligne -->
@@ -76,8 +76,8 @@
               <input v-model="edit.ip" class="input mono" aria-label="IP" @keydown.enter.prevent="saveEdit(row)" />
               <input v-model="edit.label" class="input" aria-label="Label" @keydown.enter.prevent="saveEdit(row)" />
               <span class="col-actions">
-                <button class="btn image-btn" @click="saveEdit(row)" :disabled="busy" title="Enregistrer (Entrée)">✅</button>
-                <button class="btn image-btn" @click="editingKey = null" title="Annuler">↩️</button>
+                <button type="button" class="btn image-btn" @click="saveEdit(row)" :disabled="busy" title="Enregistrer (Entrée)">✅</button>
+                <button type="button" class="btn image-btn" @click="editingKey = null" title="Annuler">↩️</button>
               </span>
             </template>
             <template v-else>
@@ -90,8 +90,8 @@
               <span class="text mono">{{ row.ip || "-" }}</span>
               <span class="text">{{ row.label || "-" }}</span>
               <span class="col-actions">
-                <button class="btn image-btn" @click="startEdit(row)" title="Éditer">✏️</button>
-                <button class="btn image-btn" @click="deleteRow(row)" :disabled="busy" title="Supprimer">🗑️</button>
+                <button type="button" class="btn image-btn" @click="startEdit(row)" title="Éditer">✏️</button>
+                <button type="button" class="btn image-btn" @click="deleteRow(row)" :disabled="busy" title="Supprimer">🗑️</button>
               </span>
             </template>
           </div>

--- a/src/components/NavBar/TopBar.vue
+++ b/src/components/NavBar/TopBar.vue
@@ -5,26 +5,26 @@
 -->
 <template>
   <div class="top-bar">
-    <button class="image-btn" @click="start" title="Démarrer (ctrl+p)" aria-label="Démarrer la capture" :disabled="isRunning || activePanel !== null">
+    <button type="button" class="image-btn" @click="start" title="Démarrer (ctrl+p)" aria-label="Démarrer la capture" :disabled="isRunning || activePanel !== null">
       <img src="../../../src-tauri/icons/StoreLogo.png" alt="Flux" class="icon-img" />
     </button>
 
-    <button class="image-btn" @click="stop" title="Arrêter (ctrl+shift+p)" aria-label="Arrêter la capture" :disabled="!isRunning">🛑</button>
-    <button class="image-btn" @click="reset" :disabled="activePanel !== null" title="Réinitialiser (ctrl+shift+r)" aria-label="Réinitialiser">🔄</button>
-    <button class="image-btn" title="Config (ctrl+,)" aria-label="Configuration" :disabled="isRunning" @click="handleConfigClick">
+    <button type="button" class="image-btn" @click="stop" title="Arrêter (ctrl+shift+p)" aria-label="Arrêter la capture" :disabled="!isRunning">🛑</button>
+    <button type="button" class="image-btn" @click="reset" :disabled="activePanel !== null" title="Réinitialiser (ctrl+shift+r)" aria-label="Réinitialiser">🔄</button>
+    <button type="button" class="image-btn" title="Config (ctrl+,)" aria-label="Configuration" :disabled="isRunning" @click="handleConfigClick">
       <img src="../../assets/mdi--gear.svg" alt="Configuration" class="icon-img" />
     </button>
 
-    <button class="image-btn" @click="triggerSave" title="Sauvegarder (ctrl+s)" aria-label="Sauvegarder la matrice de flux">💾</button>
-    <button class="image-btn" @click="SaveLabels" title="Exporter les labels" aria-label="Exporter les labels">🏷️</button>
-    <button class="image-btn" @click="handleLabelsClick" :disabled="isRunning" title="Gérer les labels" aria-label="Gérer les labels">🗂️</button>
+    <button type="button" class="image-btn" @click="triggerSave" title="Sauvegarder (ctrl+s)" aria-label="Sauvegarder la matrice de flux">💾</button>
+    <button type="button" class="image-btn" @click="SaveLabels" title="Exporter les labels" aria-label="Exporter les labels">🏷️</button>
+    <button type="button" class="image-btn" @click="handleLabelsClick" :disabled="isRunning" title="Gérer les labels" aria-label="Gérer les labels">🗂️</button>
 
-    <button class="image-btn" @click="displayPcapOpener" :disabled="isRunning || captureStore.hasData" title="Ouvrir un fichier Pcap ou une matrice de flux (ctrl+o)" aria-label="Ouvrir un fichier Pcap ou une matrice de flux">📄</button>
-    <button class="image-btn" @click="displayCsvOpener" :disabled="isRunning" title="Importer un fichier de label"><img src="../../assets/images/import_csv.png" alt="Importer un fichier de label" /></button>
+    <button type="button" class="image-btn" @click="displayPcapOpener" :disabled="isRunning || captureStore.hasData" title="Ouvrir un fichier Pcap ou une matrice de flux (ctrl+o)" aria-label="Ouvrir un fichier Pcap ou une matrice de flux">📄</button>
+    <button type="button" class="image-btn" @click="displayCsvOpener" :disabled="isRunning" title="Importer un fichier de label"><img src="../../assets/images/import_csv.png" alt="Importer un fichier de label" /></button>
 
-    <button class="image-btn" @click="quit" title="Quitter (ctrl+q)" aria-label="Quitter">❎</button>
-    <button class="image-btn" @click="export_logs" title="Logs (ctrl+l)" aria-label="Exporter les logs">📒</button>
-    <button class="image-btn" @click="handleFilterClick" :disabled="isRunning" title="Filtrer (ctrl+f)" aria-label="Filtrer">🔍</button>
+    <button type="button" class="image-btn" @click="quit" title="Quitter (ctrl+q)" aria-label="Quitter">❎</button>
+    <button type="button" class="image-btn" @click="export_logs" title="Logs (ctrl+l)" aria-label="Exporter les logs">📒</button>
+    <button type="button" class="image-btn" @click="handleFilterClick" :disabled="isRunning" title="Filtrer (ctrl+f)" aria-label="Filtrer">🔍</button>
   </div>
 </template>
 

--- a/src/components/NavBar/status-bar/StatusBar.vue
+++ b/src/components/NavBar/status-bar/StatusBar.vue
@@ -16,7 +16,7 @@
       <div v-if="captureStore.activeFilter" class="filter-badge" :title="captureStore.activeFilter">
         <span class="filter-icon">⚗</span>
         <span class="filter-text">{{ captureStore.activeFilter }}</span>
-        <button class="filter-clear" @click="clearFilter" title="Supprimer le filtre">✕</button>
+        <button type="button" class="filter-clear" @click="clearFilter" title="Supprimer le filtre">✕</button>
       </div>
       <p
         v-if="lastImport"

--- a/src/errors/capture.ts
+++ b/src/errors/capture.ts
@@ -210,7 +210,27 @@ export function isImportCancellation(err: unknown): boolean {
 export function capList<T>(items: T[], format: (item: T) => string, max = 8): string {
   const shown = items.slice(0, max).map(format).join('\n');
   const rest = items.length - max;
-  return rest > 0 ? `${shown}\n… et ${rest} autre${rest > 1 ? 's' : ''}` : shown;
+  if (rest <= 0) return shown;
+  const plural = rest > 1 ? 's' : '';
+  return `${shown}\n… et ${rest} autre${plural}`;
+}
+
+// Formateurs des lignes détaillées de handleLabelerror, extraits pour éviter
+// des template literals imbriqués dans les callbacks passés à capList.
+function formatInvalidField([line, value, row]: InvalidFieldValue): string {
+  return `ligne ${line}: ${value} | ${row}`;
+}
+
+function formatMacConflict([lineA, lineB, ip, refMac, mac]: LabelConflictRow): string {
+  return `lignes ${lineA}/${lineB} - ${ip} : ${refMac} <-> ${mac}`;
+}
+
+function formatLabelConflict([lineA, lineB, ip, refLabel, label]: LabelConflictRow): string {
+  return `lignes ${lineA}/${lineB} - ${ip} : ${refLabel} <-> ${label}`;
+}
+
+function formatInvalidRow([line, value]: InvalidLineValue): string {
+  return `ligne ${line}: ${value}`;
 }
 
 export function handleLabelerror(labelError: LabelErrorKind): string {
@@ -225,10 +245,10 @@ export function handleLabelerror(labelError: LabelErrorKind): string {
       const [invalidMac, invalidIp] = labelError.message;
       const parts = [];
       if (invalidMac.length > 0) {
-        parts.push(`MAC invalides (${invalidMac.length}) :\n${capList(invalidMac, ([line, mac, row]) => `ligne ${line}: ${mac} | ${row}`)}`);
+        parts.push(`MAC invalides (${invalidMac.length}) :\n${capList(invalidMac, formatInvalidField)}`);
       }
       if (invalidIp.length > 0) {
-        parts.push(`IP invalides (${invalidIp.length}) :\n${capList(invalidIp, ([line, ip, row]) => `ligne ${line}: ${ip} | ${row}`)}`);
+        parts.push(`IP invalides (${invalidIp.length}) :\n${capList(invalidIp, formatInvalidField)}`);
       }
       return `Formats invalides.\n${parts.join('\n\n')}`;
     }
@@ -236,15 +256,15 @@ export function handleLabelerror(labelError: LabelErrorKind): string {
       const [sameIpDiffMac, sameIpDiffLabel] = labelError.message;
       const parts = [];
       if (sameIpDiffMac.length > 0) {
-        parts.push(`même IP, MAC différent (${sameIpDiffMac.length}) :\n${capList(sameIpDiffMac, ([lineA, lineB, ip, ref_mac, mac]) => `lignes ${lineA}/${lineB} - ${ip} : ${ref_mac} <-> ${mac}`)}`);
+        parts.push(`même IP, MAC différent (${sameIpDiffMac.length}) :\n${capList(sameIpDiffMac, formatMacConflict)}`);
       }
       if (sameIpDiffLabel.length > 0) {
-        parts.push(`même IP, label différent (${sameIpDiffLabel.length}) :\n${capList(sameIpDiffLabel, ([lineA, lineB, ip, ref_label, label]) => `lignes ${lineA}/${lineB} - ${ip} : ${ref_label} <-> ${label}`)}`);
+        parts.push(`même IP, label différent (${sameIpDiffLabel.length}) :\n${capList(sameIpDiffLabel, formatLabelConflict)}`);
       }
       return `Conflits dans les lignes de labels.\n${parts.join('\n\n')}\n<Importation impossible>`;
     }
     case "invalidRowsFormat":
-      return `Format de fichier invalide. Attendu au moins "mac, ip, label" (colonnes suivantes ajoutées au label).\n${capList(labelError.message, ([line, value]) => `ligne ${line}: ${value}`)}`
+      return `Format de fichier invalide. Attendu au moins "mac, ip, label" (colonnes suivantes ajoutées au label).\n${capList(labelError.message, formatInvalidRow)}`
     case "editRejected":
       return `Édition refusée : ${labelError.message}`;
     default:

--- a/src/tests/reproBuildPolicy.test.ts
+++ b/src/tests/reproBuildPolicy.test.ts
@@ -82,8 +82,12 @@ Deno.test("les pins xwin du Dockerfile suivent la source de vérité", () => {
   );
   assert(toolchainStage >= 0);
   assert(
-    toolchainStage < rustupPin && rustupPin < targetInstall,
-    "le stage Windows doit sélectionner le toolchain installé avant sa cible",
+    toolchainStage < rustupPin,
+    "le pin RUSTUP_TOOLCHAIN doit apparaître après le stage windows-toolchain",
+  );
+  assert(
+    rustupPin < targetInstall,
+    "l'installation de la cible x86_64-pc-windows-msvc doit suivre le pin RUSTUP_TOOLCHAIN",
   );
   assert(
     dockerfile.includes("RUN bash /usr/local/bin/cache-xwin-toolchain.sh"),

--- a/src/utils/protocolColors.ts
+++ b/src/utils/protocolColors.ts
@@ -150,6 +150,10 @@ function protocolColorKey(label: string): string {
 function fallbackColorForKey(key: string): string {
   let hash = 0
   for (let i = 0; i < key.length; i++) {
+    // `| 0` n'est pas une troncature de flottant ici (hash est déjà entier) :
+    // c'est un rebouclage volontaire sur 32 bits signés (hash de type
+    // String.hashCode Java), qui borne la valeur pour des clés longues.
+    // `Math.trunc` ne reproduit pas ce rebouclage — ne pas « corriger » S7767 ici.
     hash = (hash * 31 + key.charCodeAt(i)) | 0
   }
   return HASH_FALLBACK_COLORS[Math.abs(hash) % HASH_FALLBACK_COLORS.length]


### PR DESCRIPTION
## Summary
Follow-up to #176 — works through the remaining SonarCloud findings on `main` after that merge (0 bugs, 4 vulnerabilities, 186 code smells at the time):

- **fix(security)** — 4 `Math.random()` vulnerabilities (S2245) replaced with a `crypto.getRandomValues()`-based `randomFloat()`. Both call sites are cosmetic node-position jitter, not security-sensitive, but the swap is a safe drop-in with no behavior change.
- **chore(a11y)** — 56 `<button>` elements missing an explicit `type` (S9011, defaults to `submit`); `ConfigPanel.vue`'s tooltip triggers were a focusable `<span>` (S6845, tabindex only belongs on genuinely interactive elements) turned into `<button type="button">`; `ConflictDialog.vue` used `<label>` purely for layout with no associated control (S6853) swapped for `<div>`; a mismatched `aria-label` removed from `ImportPanel.vue`'s cancel button (S7927).
- **fix(quality)** — nested template-literal formatter callbacks extracted to named functions (S4624), nested ternaries extracted/simplified (S3358), a composite test assertion split so failures say which condition broke (S9073).

**Explicitly NOT changed, with reasoning left in the diff/commit messages:**
- `protocolColors.ts`'s `| 0` — tried `Math.trunc()`, reverted: it's a deliberate 32-bit hash wraparound, not float truncation, and the substitution silently changes behavior for long strings.
- `NodeId`/`EdgeId` type aliases (S6564, "redundant since equal to string") — kept, they document intent at real call sites (`EdgeData.source`/`target`, `edgeKey()`'s return type).
- `role="dialog"` on 5 modals (S6819, "prefer native `<dialog>`") — the WAI-ARIA pattern already established by `LabelsPanel.vue` pre-existing in this codebase; native `<dialog>` would need `showModal()`/backdrop/focus restructuring across every modal component.
- CSS contrast findings (css:S7924, 5 instances) — real design-color decisions (badges, chips, disabled select), not mechanical fixes; left for a human call.
- 20 BLOCKER "test file has no tests" (S2187) and 44 "hardcoded IP" (S1313) — false positives already covered in #176's description (Deno's native test API isn't recognized by the scanner; the IPs are all in a generated test-fixture file).

## Test plan
- [x] `deno task typecheck` / `lint` / `test` (166 tests) all green after each commit
- [x] `deno task build` clean
- [x] Spot-checked `graphStyle.test.ts`'s existing `darken`/`brighten` value assertions still pass after the `Math.trunc` swap (confirms no truncation-behavior change for RGB floats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)