### PR TITLE
refactor: cut cognitive complexity below SonarCloud threshold, fix contrast

### DIFF
--- a/src-tauri/src/commandes/import/labels/conflicts.rs
+++ b/src-tauri/src/commandes/import/labels/conflicts.rs
@@ -108,6 +108,30 @@ pub(super) fn dedup_labels_first_wins(
     (kept_rows, conflicts)
 }
 
+/// Même clé de store `(mac, ip)` mais label différent -> écrasement
+/// silencieux -> conflit réel. `None` sinon. Extrait de
+/// `verif_labels_conflicts` pour garder sa complexité cognitive sous le
+/// seuil Sonar (18 -> hors seuil de 15 avec cette comparaison inline).
+#[cfg(test)]
+fn label_pair_conflict(
+    row1: &LabelRow,
+    row2: &LabelRow,
+) -> Option<(usize, usize, String, String, String, String, String)> {
+    if row1.mac == row2.mac && row1.ip == row2.ip && row1.label != row2.label {
+        Some((
+            row1.line,
+            row2.line,
+            row1.ip.clone(),
+            row1.label.clone(),
+            row2.label.clone(),
+            row1.raw.clone(),
+            row2.raw.clone(),
+        ))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 pub(super) fn verif_labels_conflicts(file_path: String) -> Result<(), CaptureStateError> {
     let rows = super::csv::read_label_rows(&file_path)?;
@@ -137,18 +161,8 @@ pub(super) fn verif_labels_conflicts(file_path: String) -> Result<(), CaptureSta
             if !is_identifying(row2) {
                 continue;
             }
-            // Même clé de store (mac, ip) mais label différent -> écrasement
-            // silencieux -> conflit réel.
-            if row1.mac == row2.mac && row1.ip == row2.ip && row1.label != row2.label {
-                same_ip_different_label.push((
-                    row1.line,
-                    row2.line,
-                    row1.ip.clone(),
-                    row1.label.clone(),
-                    row2.label.clone(),
-                    row1.raw.clone(),
-                    row2.raw.clone(),
-                ))
+            if let Some(conflict) = label_pair_conflict(row1, row2) {
+                same_ip_different_label.push(conflict);
             }
         }
     }

--- a/src-tauri/src/commandes/import/labels/csv.rs
+++ b/src-tauri/src/commandes/import/labels/csv.rs
@@ -63,6 +63,53 @@ fn is_matrix_export_header(record: &csv::StringRecord) -> bool {
     fields.next() == Some("mac_source") && fields.next() == Some("mac_destination")
 }
 
+/// Résultat du classement d'une ligne CSV lue avec succès par le parser.
+enum LabelRecordOutcome {
+    /// Ligne entièrement vide (champs blancs) : ignorée sans erreur.
+    Empty,
+    Valid(usize, csv::StringRecord),
+    Invalid(usize, String),
+}
+
+/// Classe une ligne CSV déjà parsée : vide, valide, invalide (moins de 3
+/// champs), ou erreur bloquante immédiate (mauvais type de fichier).
+/// Extrait de `read_label_records` pour garder sa complexité cognitive sous
+/// le seuil Sonar (16 -> hors seuil de 15 avec ce classement inline).
+fn classify_label_record(
+    index: usize,
+    record: csv::StringRecord,
+    fallback_line: usize,
+) -> Result<LabelRecordOutcome, CaptureStateError> {
+    let line = label_record_line(&record, fallback_line);
+    if record.iter().all(|field| clean_csv_field(field).is_empty()) {
+        return Ok(LabelRecordOutcome::Empty);
+    }
+    // Mauvais type de fichier : une matrice de flux exportée commence par son
+    // en-tête `mac_source,mac_destination,…`. Sans cette détection, chacune
+    // de ses lignes devenait une « erreur MAC/IP » et l'utilisateur recevait
+    // des centaines d'erreurs au lieu d'un diagnostic clair.
+    if index == 0 && is_matrix_export_header(&record) {
+        return Err(LabelError::InvalidRowsFormat {
+            invalid_lines: vec![(
+                line,
+                "ce fichier est une matrice de flux exportée (colonnes \
+                 mac_source, mac_destination…) : importez-le via « Ouvrir \
+                 un fichier CSV ». Un fichier de labels contient mac, ip, label."
+                    .to_string(),
+            )],
+        }
+        .into());
+    }
+    if record.len() < 3 {
+        Ok(LabelRecordOutcome::Invalid(
+            line,
+            label_record_to_display(&record),
+        ))
+    } else {
+        Ok(LabelRecordOutcome::Valid(line, record))
+    }
+}
+
 fn read_label_records(
     csv_path: &str,
 ) -> Result<Vec<(usize, csv::StringRecord)>, CaptureStateError> {
@@ -79,34 +126,11 @@ fn read_label_records(
     for (index, result) in rdr.records().enumerate() {
         let fallback_line = index + 1;
         match result {
-            Ok(record) => {
-                let line = label_record_line(&record, fallback_line);
-                if record.iter().all(|field| clean_csv_field(field).is_empty()) {
-                    continue;
-                }
-                // Mauvais type de fichier : une matrice de flux exportée
-                // commence par son en-tête `mac_source,mac_destination,…`.
-                // Sans cette détection, chacune de ses lignes devenait une
-                // « erreur MAC/IP » et l'utilisateur recevait des centaines
-                // d'erreurs au lieu d'un diagnostic clair.
-                if index == 0 && is_matrix_export_header(&record) {
-                    return Err(LabelError::InvalidRowsFormat {
-                        invalid_lines: vec![(
-                            line,
-                            "ce fichier est une matrice de flux exportée (colonnes \
-                             mac_source, mac_destination…) : importez-le via « Ouvrir \
-                             un fichier CSV ». Un fichier de labels contient mac, ip, label."
-                                .to_string(),
-                        )],
-                    }
-                    .into());
-                }
-                if record.len() < 3 {
-                    invalid_lines.push((line, label_record_to_display(&record)));
-                } else {
-                    records.push((line, record));
-                }
-            }
+            Ok(record) => match classify_label_record(index, record, fallback_line)? {
+                LabelRecordOutcome::Empty => continue,
+                LabelRecordOutcome::Valid(line, record) => records.push((line, record)),
+                LabelRecordOutcome::Invalid(line, display) => invalid_lines.push((line, display)),
+            },
             Err(error) => {
                 invalid_lines.push((label_error_line(&error, fallback_line), error.to_string()))
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,49 @@ mod utils;
 // Exposé pour le benchmark `examples/pool_bench.rs`.
 pub use state::capture::capture_handle::threads::packet_buffer;
 
+/// Gère les clics du menu natif (À propos, Changelog, Fermer).
+fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
+    if event.id() == "version" {
+        app.dialog()
+            .message(about_message())
+            .title("À propos de SONAR")
+            .kind(MessageDialogKind::Info)
+            .buttons(MessageDialogButtons::Ok)
+            .show(|_| {});
+    } else if event.id() == "changelog" {
+        app.dialog()
+            .message(changelog_message())
+            .title("Changelog")
+            .kind(MessageDialogKind::Info)
+            .buttons(MessageDialogButtons::Ok)
+            .show(|_| {});
+    } else if event.id() == "fermer" {
+        if let Some(window) = app.get_webview_window("main") {
+            if let Err(close_error) = window.close() {
+                error!("Failed to close main window: {close_error}");
+            }
+        } else {
+            app.exit(0);
+        }
+    }
+}
+
+/// Recharge la configuration de capture persistée au démarrage, si présente.
+fn restore_persisted_capture_config(app: &tauri::AppHandle) {
+    let capture_state = app.state::<Arc<Mutex<CaptureState>>>();
+    match CaptureConfig::load_persisted(app) {
+        Ok(Some(config)) => match capture_state.lock() {
+            Ok(mut state) => {
+                info!("Configuration capture chargée depuis le disque");
+                state.config = config;
+            }
+            Err(err) => error!("Impossible de charger la configuration capture: {err}"),
+        },
+        Ok(None) => {}
+        Err(err) => error!("Configuration capture persistée ignorée: {err}"),
+    }
+}
+
 /// Point d'entrée de l'application : configure les plugins, l'état partagé,
 /// le menu et la fenêtre, puis démarre la boucle Tauri.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -98,31 +141,7 @@ pub fn run() -> Result<(), tauri::Error> {
         .manage(Arc::new(Mutex::new(PcInfoLabel::new())))
         .manage(Arc::new(Mutex::new(LabelStore::new())))
         .manage(Arc::new(Mutex::new(LabelConflictStore::default())))
-        .on_menu_event(|app, event| {
-            if event.id() == "version" {
-                app.dialog()
-                    .message(about_message())
-                    .title("À propos de SONAR")
-                    .kind(MessageDialogKind::Info)
-                    .buttons(MessageDialogButtons::Ok)
-                    .show(|_| {});
-            } else if event.id() == "changelog" {
-                app.dialog()
-                    .message(changelog_message())
-                    .title("Changelog")
-                    .kind(MessageDialogKind::Info)
-                    .buttons(MessageDialogButtons::Ok)
-                    .show(|_| {});
-            } else if event.id() == "fermer" {
-                if let Some(window) = app.get_webview_window("main") {
-                    if let Err(close_error) = window.close() {
-                        error!("Failed to close main window: {close_error}");
-                    }
-                } else {
-                    app.exit(0);
-                }
-            }
-        })
+        .on_menu_event(handle_menu_event)
         .setup({
             move |app| {
                 info!("{}", print_banner());
@@ -131,18 +150,7 @@ pub fn run() -> Result<(), tauri::Error> {
                 info!("Reading labels...");
                 read_labels(app.handle())?;
 
-                let capture_state = app.state::<Arc<Mutex<CaptureState>>>();
-                match CaptureConfig::load_persisted(app.handle()) {
-                    Ok(Some(config)) => match capture_state.lock() {
-                        Ok(mut state) => {
-                            info!("Configuration capture chargée depuis le disque");
-                            state.config = config;
-                        }
-                        Err(err) => error!("Impossible de charger la configuration capture: {err}"),
-                    },
-                    Ok(None) => {}
-                    Err(err) => error!("Configuration capture persistée ignorée: {err}"),
-                }
+                restore_persisted_capture_config(app.handle());
 
                 let _ = start_cpu_monitor(app.handle().clone());
 

--- a/src/components/AnalyseView/NetworkGraphComponent.vue
+++ b/src/components/AnalyseView/NetworkGraphComponent.vue
@@ -25,6 +25,7 @@ import {
   EDGE_LABEL_ZOOM,
   PORT_LABEL_ZOOM,
   drawNodeLabel,
+  edgeLabelFor,
   nodeAttributes,
 } from "./graph/graphStyle"
 import {
@@ -248,26 +249,7 @@ export default defineComponent({
           res.size = (data.size || 1) + 1
         }
       }
-      if (!this._edgeLabelsShown || dimmed) {
-        res.label = null
-        return res
-      }
-      let label = data.protocol ?? ""
-      if (this._portLabelsShown) {
-        const ports: number[] = Array.isArray(data.ports) ? data.ports : []
-        const hasDynamic = data.has_dynamic_ports === true
-        if (ports.length > 0) {
-          // Ports « service » de l'arête (les éphémères ne sont pas listés,
-          // le backend les résume par has_dynamic_ports → « … »).
-          label += ` :${ports.join(",")}${hasDynamic ? ",…" : ""}`
-        } else if (hasDynamic) {
-          // Uniquement du trafic sur ports dynamiques : signalé sans liste.
-          label += " :…"
-        } else if (data.source_port != null || data.destination_port != null) {
-          label += ` ${data.source_port ?? ""}→${data.destination_port ?? ""}`
-        }
-      }
-      res.label = label
+      res.label = (!this._edgeLabelsShown || dimmed) ? null : edgeLabelFor(data, this._portLabelsShown)
       return res
     },
 

--- a/src/components/AnalyseView/graph/graphStyle.ts
+++ b/src/components/AnalyseView/graph/graphStyle.ts
@@ -147,3 +147,37 @@ export function edgeAttributes(e: Edge) {
     size: edgeSizeFor(totalBytes),
   }
 }
+
+// --- Libellé d'arête rendu (reducer Sigma) -----------------------------------
+interface EdgeLabelSource {
+  protocol?: string
+  ports?: number[]
+  has_dynamic_ports?: boolean
+  source_port?: number | string | null
+  destination_port?: number | string | null
+}
+
+/** Libellé d'arête affiché par le edgeReducer de NetworkGraphComponent.vue :
+ *  protocole, plus le détail des ports si affiché à ce niveau de zoom.
+ *  Extrait du reducer (complexité cognitive 18, hors du seuil Sonar de 15)
+ *  pour rester une fonction pure testable indépendamment. */
+export function edgeLabelFor(data: EdgeLabelSource, portLabelsShown: boolean): string {
+  const protocol = data.protocol ?? ""
+  if (!portLabelsShown) return protocol
+
+  const ports: number[] = Array.isArray(data.ports) ? data.ports : []
+  const hasDynamic = data.has_dynamic_ports === true
+  if (ports.length > 0) {
+    // Ports « service » de l'arête (les éphémères ne sont pas listés,
+    // le backend les résume par has_dynamic_ports → « … »).
+    return `${protocol} :${ports.join(",")}${hasDynamic ? ",…" : ""}`
+  }
+  if (hasDynamic) {
+    // Uniquement du trafic sur ports dynamiques : signalé sans liste.
+    return `${protocol} :…`
+  }
+  if (data.source_port != null || data.destination_port != null) {
+    return `${protocol} ${data.source_port ?? ""}→${data.destination_port ?? ""}`
+  }
+  return protocol
+}

--- a/src/components/AnalyseView/panels/ConfigPanel.vue
+++ b/src/components/AnalyseView/panels/ConfigPanel.vue
@@ -384,7 +384,9 @@ select:focus {
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  background-color: #007bff;
+  /* #007bff était sous le seuil WCAG AA avec du texte blanc (3.98:1) ;
+     même bleu, légèrement assombri pour passer 4.5:1. */
+  background-color: #0071eb;
   color: white;
   font-weight: bold;
   transition: background-color 0.2s;

--- a/src/components/AnalyseView/panels/Filter.vue
+++ b/src/components/AnalyseView/panels/Filter.vue
@@ -488,7 +488,9 @@ function preset(name: string) {
 }
 .row code {
   font-size: 11px;
-  color: #6080c0;
+  /* #6080c0 était sous le seuil WCAG AA (4.34:1 sur #1a1a2e) ; même teinte,
+     légèrement éclaircie pour passer 4.5:1. */
+  color: #6483c1;
   background: #1a1a2e;
   padding: 1px 4px;
   border-radius: 3px;
@@ -628,7 +630,9 @@ function preset(name: string) {
 }
 .chip {
   background: #1e1e30;
-  color: #8080b0;
+  /* #8080b0 était sous le seuil WCAG AA (4.39:1 sur #1e1e30) ; même teinte,
+     légèrement éclaircie pour passer 4.5:1. */
+  color: #8383b2;
   border: 1px solid #2d2d50;
   border-radius: 999px;
   padding: 5px 13px;

--- a/src/store/capture.ts
+++ b/src/store/capture.ts
@@ -128,90 +128,113 @@ export const useCaptureStore = defineStore("capture", {
       __channel = markRaw(channel);
 
       __channel.onmessage = (msg: CaptureEvent) => {
-        // Filtrage de session : les événements de capture live portent le
-        // sessionId de leur pipeline (0 = hors session, ex. import). Un id
-        // différent de la session courante signale un événement périmé.
-        const sid = "sessionId" in msg.data ? msg.data.sessionId : undefined;
-        if (typeof sid === "number" && sid > 0) {
-          if (msg.event === "started") {
-            if (sid < this.sessionId) {
-              warn(`[CaptureStore] started d'une session périmée ignoré (${sid} < ${this.sessionId})`);
-              return;
-            }
-            this.sessionId = sid;
-          } else if (sid !== this.sessionId) {
-            warn(`[CaptureStore] ${msg.event} d'une session périmée ignoré (${sid} ≠ ${this.sessionId})`);
-            return;
-          }
-        }
-        switch (msg.event) {
-          case "started":
-            if (msg.data.protocolVersion !== EXPECTED_PROTOCOL_VERSION) {
-              warn(
-                `[CaptureStore] version du contrat IPC inattendue : reçu ${msg.data.protocolVersion}, attendu ${EXPECTED_PROTOCOL_VERSION} — frontend et backend probablement désynchronisés`
-              );
-            }
-            if (this.pendingFilter) {
-              this.activeFilter = this.pendingFilter;
-              this.pendingFilter = '';
-            }
-            this.linkType = msg.data.linkType;
-            for (const cb of this.startedListeners) cb(msg.data);
-            break;
-          case "finished":
-            for (const cb of this.finishedListeners) cb(msg.data);
-            break;
-          case "stopped":
-            info(`[CaptureStore] Capture arrêtée : ${msg.data.reason}`);
-            // Arrêt initié par le backend (ex. erreur pcap) : sans cette mise
-            // à jour, l'UI croirait capturer indéfiniment.
-            this.lastStoppedSessionId = Math.max(this.lastStoppedSessionId, msg.data.sessionId);
-            this.isRunning = false;
-            for (const cb of this.stoppedListeners) cb(msg.data);
-            break;
-          case "packetBatch": {
-            const packets = msg.data.packets;
-            // Il n'existe pas d'événement `packet` unitaire sur le fil (#142)
-            // : c'est ici que la présence de données doit être détectée, et
-            // que `packetListeners` (abonnés par paquet, cf. `onPacket`) est
-            // nourri à partir des batches — un même consommateur ne doit
-            // s'abonner qu'à l'un des deux (`onPacket` XOR `onPacketBatch`),
-            // sous peine de recevoir chaque paquet deux fois.
-            if (packets.length > 0 && !this.hasData) this.hasData = true;
-
-            for (const cb of this.packetBatchListeners) cb(packets);
-
-            if (this.packetListeners.length > 0) {
-              for (const packet of packets) {
-                for (const cb of this.packetListeners) cb(packet);
-              }
-            }
-            break;
-          }
-          case "stats":
-            for (const cb of this.statsListeners) cb(msg.data);
-            break;
-          case "importProgress":
-            this.importProgress = msg.data;
-            break;
-          case "channelCapacityPayload":
-            for (const cb of this.channelCapacityPayloadListeners) cb(msg.data);
-            break;
-          case "graph":
-            for (const cb of this.graphUpdateListeners) cb(msg.data.update);
-            break;
-          case "graphBatch":
-            for (const update of msg.data.updates) {
-              for (const cb of this.graphUpdateListeners) cb(update);
-            }
-            break;
-          case "graphSnapshot":
-            for (const cb of this.graphSnapshotListeners) cb(msg.data.graphData);
-            break;
-          default:
-            logUnknownEvent(msg);
-        }
+        if (this.shouldProcessCaptureEvent(msg)) this.dispatchCaptureEvent(msg);
       };
+    },
+
+    // Filtrage de session : les événements de capture live portent le
+    // sessionId de leur pipeline (0 = hors session, ex. import). Un id
+    // différent de la session courante signale un événement périmé.
+    // Effet de bord assumé : promeut sessionId sur un `started` valide,
+    // seul événement qui fait avancer la session courante.
+    shouldProcessCaptureEvent(msg: CaptureEvent): boolean {
+      const sid = "sessionId" in msg.data ? msg.data.sessionId : undefined;
+      if (typeof sid !== "number" || sid <= 0) return true;
+
+      if (msg.event === "started") {
+        if (sid < this.sessionId) {
+          warn(`[CaptureStore] started d'une session périmée ignoré (${sid} < ${this.sessionId})`);
+          return false;
+        }
+        this.sessionId = sid;
+        return true;
+      }
+      if (sid !== this.sessionId) {
+        warn(`[CaptureStore] ${msg.event} d'une session périmée ignoré (${sid} ≠ ${this.sessionId})`);
+        return false;
+      }
+      return true;
+    },
+
+    dispatchCaptureEvent(msg: CaptureEvent) {
+      switch (msg.event) {
+        case "started":
+          this.handleStartedEvent(msg.data);
+          break;
+        case "finished":
+          for (const cb of this.finishedListeners) cb(msg.data);
+          break;
+        case "stopped":
+          this.handleStoppedEvent(msg.data);
+          break;
+        case "packetBatch":
+          this.handlePacketBatchEvent(msg.data);
+          break;
+        case "stats":
+          for (const cb of this.statsListeners) cb(msg.data);
+          break;
+        case "importProgress":
+          this.importProgress = msg.data;
+          break;
+        case "channelCapacityPayload":
+          for (const cb of this.channelCapacityPayloadListeners) cb(msg.data);
+          break;
+        case "graph":
+          for (const cb of this.graphUpdateListeners) cb(msg.data.update);
+          break;
+        case "graphBatch":
+          for (const update of msg.data.updates) {
+            for (const cb of this.graphUpdateListeners) cb(update);
+          }
+          break;
+        case "graphSnapshot":
+          for (const cb of this.graphSnapshotListeners) cb(msg.data.graphData);
+          break;
+        default:
+          logUnknownEvent(msg);
+      }
+    },
+
+    handleStartedEvent(data: EventData<"started">) {
+      if (data.protocolVersion !== EXPECTED_PROTOCOL_VERSION) {
+        warn(
+          `[CaptureStore] version du contrat IPC inattendue : reçu ${data.protocolVersion}, attendu ${EXPECTED_PROTOCOL_VERSION} — frontend et backend probablement désynchronisés`
+        );
+      }
+      if (this.pendingFilter) {
+        this.activeFilter = this.pendingFilter;
+        this.pendingFilter = '';
+      }
+      this.linkType = data.linkType;
+      for (const cb of this.startedListeners) cb(data);
+    },
+
+    handleStoppedEvent(data: EventData<"stopped">) {
+      info(`[CaptureStore] Capture arrêtée : ${data.reason}`);
+      // Arrêt initié par le backend (ex. erreur pcap) : sans cette mise à
+      // jour, l'UI croirait capturer indéfiniment.
+      this.lastStoppedSessionId = Math.max(this.lastStoppedSessionId, data.sessionId);
+      this.isRunning = false;
+      for (const cb of this.stoppedListeners) cb(data);
+    },
+
+    handlePacketBatchEvent(data: EventData<"packetBatch">) {
+      const packets = data.packets;
+      // Il n'existe pas d'événement `packet` unitaire sur le fil (#142) :
+      // c'est ici que la présence de données doit être détectée, et que
+      // `packetListeners` (abonnés par paquet, cf. `onPacket`) est nourri à
+      // partir des batches — un même consommateur ne doit s'abonner qu'à
+      // l'un des deux (`onPacket` XOR `onPacketBatch`), sous peine de
+      // recevoir chaque paquet deux fois.
+      if (packets.length > 0 && !this.hasData) this.hasData = true;
+
+      for (const cb of this.packetBatchListeners) cb(packets);
+
+      if (this.packetListeners.length > 0) {
+        for (const packet of packets) {
+          for (const cb of this.packetListeners) cb(packet);
+        }
+      }
     },
 
     getChannel(): Channel<CaptureEvent> | undefined {

--- a/src/tests/graphStyle.test.ts
+++ b/src/tests/graphStyle.test.ts
@@ -14,6 +14,7 @@ import {
   darken,
   edgeAttributes,
   edgeKey,
+  edgeLabelFor,
   edgeSizeFor,
   formatBytes,
   getCurvature,
@@ -187,4 +188,34 @@ Deno.test("edgeAttributes - transmet ports/tunnels tels quels", () => {
   assertEquals(attrs.has_dynamic_ports, true);
   assertEquals(attrs.encapIds, ["enc-1"]);
   assertEquals(attrs.total_bytes, 12345);
+});
+
+Deno.test("edgeLabelFor - ports masqués -> seulement le protocole", () => {
+  assertEquals(edgeLabelFor({ protocol: "TCP", ports: [80] }, false), "TCP");
+});
+
+Deno.test("edgeLabelFor - ports affichés, liste de ports -> protocole + ports triés", () => {
+  assertEquals(edgeLabelFor({ protocol: "TCP", ports: [80, 443] }, true), "TCP :80,443");
+});
+
+Deno.test("edgeLabelFor - ports affichés, ports dynamiques mêlés à des ports listés -> suffixe …", () => {
+  assertEquals(
+    edgeLabelFor({ protocol: "TCP", ports: [80], has_dynamic_ports: true }, true),
+    "TCP :80,…"
+  );
+});
+
+Deno.test("edgeLabelFor - ports affichés, uniquement dynamiques -> pas de liste", () => {
+  assertEquals(edgeLabelFor({ protocol: "TCP", ports: [], has_dynamic_ports: true }, true), "TCP :…");
+});
+
+Deno.test("edgeLabelFor - ports affichés, ports source/destination sans liste -> flèche", () => {
+  assertEquals(
+    edgeLabelFor({ protocol: "TCP", ports: [], source_port: 51234, destination_port: 443 }, true),
+    "TCP 51234→443"
+  );
+});
+
+Deno.test("edgeLabelFor - ports affichés, rien à montrer -> seulement le protocole", () => {
+  assertEquals(edgeLabelFor({ protocol: "ICMP", ports: [] }, true), "ICMP");
 });


### PR DESCRIPTION
## Summary
Continues the SonarCloud cleanup (after #176, #177) — all 8 CRITICAL cognitive-complexity findings, plus the 5 contrast findings.

**Frontend:**
- **refactor(graph)** — `NetworkGraphComponent.edgeReducer` (complexity 18) had its port-label formatting extracted to `graphStyle.edgeLabelFor()`, a pure function with 6 new unit tests. Matches this file's existing convention of keeping testable logic in `graph/*.ts` rather than inline in the component.
- **refactor(store)** — `store/capture.ts`'s `setChannel().onmessage` (complexity **47**) split into `shouldProcessCaptureEvent()` (session-staleness filter) + `dispatchCaptureEvent()` (the event switch) + 3 per-event handlers for the cases with more than a one-liner. No behavior change — verified against the 11 existing black-box `captureStore.test.ts` tests, which pass unmodified.
- **fix(a11y)** — 3 of the 5 contrast findings raised to WCAG AA (4.5:1) with minimal same-hue nudges. The other 2 are explained rather than changed: the badge already passes once its `rgba()` background is composited correctly (scanner limitation, not a real issue), and the disabled `<select>`'s low contrast is the WCAG-sanctioned way to signal non-interactivity.

**Rust (`src-tauri`):**
- **refactor** — `lib.rs::run()` (complexity 17, the app's Tauri entry point): extracted the 3-branch `on_menu_event` closure and the config-restore match into named top-level functions (`handle_menu_event`, `restore_persisted_capture_config`). No unit-testable surface here (it starts the Tauri event loop) — verified with a real release build + the maintained smoke test.
- **refactor(import)** — `csv.rs::read_label_records()` (complexity 16): per-record classification extracted into `classify_label_record()` returning a 3-variant enum. `conflicts.rs::verif_labels_conflicts()` (complexity 18, **test-only** — `#[cfg(test)]`, its own comment says the file-based detection it implements "ne sert plus qu'aux tests"; production conflict handling is `dedup_labels_first_wins()`, untouched): pairwise comparison extracted into `label_pair_conflict()`.
- **Deliberately left alone**, discussed with the user first: `capture_handle/threads/{processing.rs,capture.rs}` (complexity 56 and 34) — these are the live packet-capture and processing thread loops themselves, with state mutated across loop iterations, graceful-shutdown/drain sequencing, and no direct unit-test coverage. Given SONAR's core promise is capture fidelity, restructuring that hot path for a linter score wasn't worth the risk without a much deeper investment in test scaffolding first.

## Test plan
- [x] `deno task typecheck` / `lint` / `test` (172 tests, incl. 6 new) all green after each frontend commit
- [x] `deno task build` clean
- [x] `captureStore.test.ts`'s 11 existing tests (black-box through `setChannel`) pass unmodified after the store refactor — main regression signal for that change
- [x] Contrast ratios computed via the WCAG relative-luminance formula, not eyeballed
- [x] `cargo build --locked`, `cargo test --locked` (174 passed), `cargo clippy --locked --all-targets` (clean) after each Rust commit
- [x] Release build (`--ci --no-sign --no-bundle`) + `smoke-test-release-binary.sh` → `SONAR_STARTUP_VALIDATION=OK` after the `lib.rs::run()` change specifically, since it's the app's entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
