### PR TITLE
refactor(capture): cut cognitive complexity in the live capture/processing threads

### DIFF
--- a/src-tauri/src/state/capture/capture_handle/threads/capture.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/capture.rs
@@ -360,7 +360,14 @@ mod tests {
         let mut last_drop_report = Instant::now() - DROP_REPORT_INTERVAL - Duration::from_millis(1);
         let (on_event, events) = recording_channel();
 
-        maybe_report_drops(&mut pending_drops, &mut last_drop_report, &on_event, 9, 128, 3);
+        maybe_report_drops(
+            &mut pending_drops,
+            &mut last_drop_report,
+            &on_event,
+            9,
+            128,
+            3,
+        );
 
         assert_eq!(
             pending_drops.total(),
@@ -382,7 +389,14 @@ mod tests {
         let mut last_drop_report = Instant::now() - DROP_REPORT_INTERVAL - Duration::from_millis(1);
         let (on_event, events) = recording_channel();
 
-        maybe_report_drops(&mut pending_drops, &mut last_drop_report, &on_event, 9, 128, 3);
+        maybe_report_drops(
+            &mut pending_drops,
+            &mut last_drop_report,
+            &on_event,
+            9,
+            128,
+            3,
+        );
 
         assert!(
             events.lock().unwrap().is_empty(),
@@ -399,7 +413,14 @@ mod tests {
         let mut last_drop_report = Instant::now(); // rapport tout juste émis
         let (on_event, events) = recording_channel();
 
-        maybe_report_drops(&mut pending_drops, &mut last_drop_report, &on_event, 9, 128, 3);
+        maybe_report_drops(
+            &mut pending_drops,
+            &mut last_drop_report,
+            &on_event,
+            9,
+            128,
+            3,
+        );
 
         assert_eq!(
             pending_drops.total(),

--- a/src-tauri/src/state/capture/capture_handle/threads/capture.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/capture.rs
@@ -45,6 +45,84 @@ impl DropReport {
     }
 }
 
+/// Copie un paquet capturé dans un buffer du pool et l'envoie au thread de
+/// traitement. Retourne `true` si la boucle de capture doit continuer,
+/// `false` si le consommateur (thread de traitement) est parti et que la
+/// boucle doit s'arrêter.
+fn forward_captured_packet(
+    packet: &pcap::Packet,
+    tx: &Sender<CaptureMessage>,
+    buffer_pool: &PacketBufferPool,
+    drop_counters: &AppDropCounters,
+    pending_drops: &mut DropReport,
+) -> bool {
+    let Some(mut buffer) = buffer_pool.get(packet.header.caplen as usize) else {
+        drop_counters.add_no_buffer();
+        pending_drops.no_buffer += 1;
+        return true;
+    };
+    // On copie les octets DANS UN SCOPE LIMITE
+    buffer.write_from_parts(packet.header, packet.data);
+
+    match tx.try_send(CaptureMessage::Packet(buffer)) {
+        Ok(()) => {
+            // Succès : le processing thread RENDRA le buffer au pool.
+            true
+        }
+        Err(TrySendError::Full(message)) => {
+            drop_counters.add_channel_full();
+            pending_drops.channel_full += 1;
+            // Échec d'envoi => on remet IMMÉDIATEMENT le buffer au pool
+            let CaptureMessage::Packet(buffer) = message;
+            buffer_pool.put(buffer);
+            true
+        }
+        Err(TrySendError::Disconnected(message)) => {
+            // Le consommateur est parti (arrêt en cours) : ce paquet est
+            // arrivé après l'arrêt effectif, ce n'est pas une perte -- on
+            // rend le buffer et on sort sans le compter en « canal plein ».
+            let CaptureMessage::Packet(buffer) = message;
+            buffer_pool.put(buffer);
+            debug!("Canal fermé côté processing : fin du thread de capture");
+            false
+        }
+    }
+}
+
+/// Journalise et signale au front (best-effort) les pertes applicatives
+/// accumulées depuis le dernier rapport, au plus une fois par
+/// [`DROP_REPORT_INTERVAL`]. Réinitialise le compteur si un rapport est émis.
+#[allow(clippy::too_many_arguments)]
+fn maybe_report_drops(
+    pending_drops: &mut DropReport,
+    last_drop_report: &mut Instant,
+    on_event: &Channel<CaptureEvent<'static>>,
+    session_id: u64,
+    channel_capacity: i32,
+    tx_len: usize,
+) {
+    if pending_drops.total() == 0 || last_drop_report.elapsed() < DROP_REPORT_INTERVAL {
+        return;
+    }
+    warn!(
+        "Capture : {} paquets perdus côté app depuis {:?} (pool épuisé : {}, canal plein : {})",
+        pending_drops.total(),
+        last_drop_report.elapsed(),
+        pending_drops.no_buffer,
+        pending_drops.channel_full
+    );
+    if let Err(e) = on_event.send(CaptureEvent::ChannelCapacityPayload {
+        session_id,
+        channel_size: channel_capacity as usize,
+        current_size: tx_len,
+        backpressure: true,
+    }) {
+        error!("Erreur send channel capacity payload: {}", e);
+    }
+    *pending_drops = DropReport::default();
+    *last_drop_report = Instant::now();
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_capture_thread_with_pool(
     tx: Sender<CaptureMessage>,
@@ -84,58 +162,27 @@ pub fn spawn_capture_thread_with_pool(
 
             match cap.next_packet() {
                 Ok(packet) => {
-                    if let Some(mut buffer) = buffer_pool.get(packet.header.caplen as usize) {
-                        // On copie les octets DANS UN SCOPE LIMITE
-                        buffer.write_from_parts(packet.header, packet.data);
-
-                        match tx.try_send(CaptureMessage::Packet(buffer)) {
-                            Ok(()) => {
-                                // Succès : le processing thread RENDRA le buffer au pool.
-                            }
-                            Err(TrySendError::Full(message)) => {
-                                drop_counters.add_channel_full();
-                                pending_drops.channel_full += 1;
-                                // Échec d'envoi => on remet IMMÉDIATEMENT le buffer au pool
-                                let CaptureMessage::Packet(buffer) = message;
-                                buffer_pool.put(buffer);
-                            }
-                            Err(TrySendError::Disconnected(message)) => {
-                                // Le consommateur est parti (arrêt en cours) :
-                                // ce paquet est arrivé après l'arrêt effectif,
-                                // ce n'est pas une perte — on rend le buffer
-                                // et on sort sans le compter en « canal plein ».
-                                let CaptureMessage::Packet(buffer) = message;
-                                buffer_pool.put(buffer);
-                                debug!("Canal fermé côté processing : fin du thread de capture");
-                                break;
-                            }
-                        }
-                    } else {
-                        drop_counters.add_no_buffer();
-                        pending_drops.no_buffer += 1;
+                    let keep_going = forward_captured_packet(
+                        &packet,
+                        &tx,
+                        &buffer_pool,
+                        &drop_counters,
+                        &mut pending_drops,
+                    );
+                    // Canal déconnecté : on sort immédiatement, sans passer
+                    // par le rapport de pertes (même comportement que
+                    // l'ancien `break` inline, qui sautait le reste du bras).
+                    if !keep_going {
+                        break;
                     }
-
-                    if pending_drops.total() > 0
-                        && last_drop_report.elapsed() >= DROP_REPORT_INTERVAL
-                    {
-                        warn!(
-                            "Capture : {} paquets perdus côté app depuis {:?} (pool épuisé : {}, canal plein : {})",
-                            pending_drops.total(),
-                            last_drop_report.elapsed(),
-                            pending_drops.no_buffer,
-                            pending_drops.channel_full
-                        );
-                        if let Err(e) = on_event.send(CaptureEvent::ChannelCapacityPayload {
-                            session_id,
-                            channel_size: channel_capacity as usize,
-                            current_size: tx.len(),
-                            backpressure: true,
-                        }) {
-                            error!("Erreur send channel capacity payload: {}", e);
-                        }
-                        pending_drops = DropReport::default();
-                        last_drop_report = Instant::now();
-                    }
+                    maybe_report_drops(
+                        &mut pending_drops,
+                        &mut last_drop_report,
+                        &on_event,
+                        session_id,
+                        channel_capacity,
+                        tx.len(),
+                    );
                 }
                 Err(pcap::Error::PcapError(e)) if e.contains("Packets are not available") => {
                     thread::sleep(Duration::from_millis(1));
@@ -160,4 +207,205 @@ pub fn spawn_capture_thread_with_pool(
         }
         debug!("Thread de capture terminé.");
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam::channel::bounded;
+
+    /// Trame ARP request complète (42 octets), identique à celle utilisée
+    /// dans les tests du thread de traitement.
+    fn arp_frame() -> Vec<u8> {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[0xff; 6]); // dst broadcast
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]); // src
+        frame.extend_from_slice(&[0x08, 0x06]); // ethertype ARP
+        frame.extend_from_slice(&[0x00, 0x01]); // hw type ethernet
+        frame.extend_from_slice(&[0x08, 0x00]); // proto type IPv4
+        frame.extend_from_slice(&[0x06, 0x04]); // hlen, plen
+        frame.extend_from_slice(&[0x00, 0x01]); // opération request
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]); // sha
+        frame.extend_from_slice(&[192, 168, 1, 10]); // spa
+        frame.extend_from_slice(&[0x00; 6]); // tha
+        frame.extend_from_slice(&[192, 168, 1, 1]); // tpa
+        frame
+    }
+
+    fn test_header(data: &[u8]) -> pcap::PacketHeader {
+        pcap::PacketHeader {
+            ts: libc::timeval {
+                tv_sec: 0,
+                tv_usec: 0,
+            },
+            caplen: data.len() as u32,
+            len: data.len() as u32,
+        }
+    }
+
+    fn recording_channel() -> (
+        Channel<CaptureEvent<'static>>,
+        Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+    ) {
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let channel = Channel::new(move |body| {
+            if let tauri::ipc::InvokeResponseBody::Json(json) = body {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push(serde_json::from_str(&json).unwrap());
+            }
+            Ok(())
+        });
+        (channel, events)
+    }
+
+    #[test]
+    fn forward_captured_packet_sends_on_success() {
+        let pool = PacketBufferPool::new(4, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(4);
+        let drop_counters = AppDropCounters::default();
+        let mut pending_drops = DropReport::default();
+        let data = arp_frame();
+        let header = test_header(&data);
+        let packet = pcap::Packet::new(&header, &data);
+
+        let keep_going =
+            forward_captured_packet(&packet, &tx, &pool, &drop_counters, &mut pending_drops);
+
+        assert!(keep_going);
+        assert_eq!(pending_drops.total(), 0);
+        assert!(
+            rx.try_recv().is_ok(),
+            "le paquet est envoyé au thread de traitement"
+        );
+    }
+
+    #[test]
+    fn forward_captured_packet_counts_no_buffer_drop_when_pool_is_empty() {
+        let pool = PacketBufferPool::new(0, 65_536);
+        let (tx, _rx) = bounded::<CaptureMessage>(4);
+        let drop_counters = AppDropCounters::default();
+        let mut pending_drops = DropReport::default();
+        let data = arp_frame();
+        let header = test_header(&data);
+        let packet = pcap::Packet::new(&header, &data);
+
+        let keep_going =
+            forward_captured_packet(&packet, &tx, &pool, &drop_counters, &mut pending_drops);
+
+        assert!(keep_going, "pool épuisé : on continue, on compte la perte");
+        assert_eq!(pending_drops.no_buffer, 1);
+        assert_eq!(drop_counters.total(), 1);
+    }
+
+    #[test]
+    fn forward_captured_packet_counts_channel_full_and_returns_buffer() {
+        let pool = PacketBufferPool::new(4, 65_536);
+        // Capacité nulle : try_send échoue systématiquement en Full.
+        let (tx, _rx) = bounded::<CaptureMessage>(0);
+        let drop_counters = AppDropCounters::default();
+        let mut pending_drops = DropReport::default();
+        let data = arp_frame();
+        let header = test_header(&data);
+        let packet = pcap::Packet::new(&header, &data);
+
+        let keep_going =
+            forward_captured_packet(&packet, &tx, &pool, &drop_counters, &mut pending_drops);
+
+        assert!(keep_going);
+        assert_eq!(pending_drops.channel_full, 1);
+        // Pool à allocation paresseuse (aucun buffer dispo avant le premier
+        // `get()`) : le buffer obtenu puis rendu sur l'échec d'envoi se
+        // retrouve donc immédiatement disponible, pas perdu.
+        assert_eq!(
+            pool.len(),
+            1,
+            "le buffer est rendu au pool immédiatement sur échec d'envoi"
+        );
+    }
+
+    #[test]
+    fn forward_captured_packet_stops_the_loop_when_consumer_is_gone() {
+        let pool = PacketBufferPool::new(4, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(4);
+        drop(rx); // plus aucun récepteur : try_send échoue en Disconnected.
+        let drop_counters = AppDropCounters::default();
+        let mut pending_drops = DropReport::default();
+        let data = arp_frame();
+        let header = test_header(&data);
+        let packet = pcap::Packet::new(&header, &data);
+
+        let keep_going =
+            forward_captured_packet(&packet, &tx, &pool, &drop_counters, &mut pending_drops);
+
+        assert!(
+            !keep_going,
+            "consommateur parti -> la boucle de capture doit s'arrêter"
+        );
+        assert_eq!(
+            pending_drops.total(),
+            0,
+            "un consommateur parti n'est pas compté comme une perte"
+        );
+    }
+
+    #[test]
+    fn maybe_report_drops_fires_and_resets_after_the_interval() {
+        let mut pending_drops = DropReport {
+            no_buffer: 2,
+            channel_full: 1,
+        };
+        let mut last_drop_report = Instant::now() - DROP_REPORT_INTERVAL - Duration::from_millis(1);
+        let (on_event, events) = recording_channel();
+
+        maybe_report_drops(&mut pending_drops, &mut last_drop_report, &on_event, 9, 128, 3);
+
+        assert_eq!(
+            pending_drops.total(),
+            0,
+            "le compteur est remis à zéro après le rapport"
+        );
+        let events = events.lock().unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| e["event"] == "channelCapacityPayload"),
+            "l'occupation du canal est signalée au front"
+        );
+    }
+
+    #[test]
+    fn maybe_report_drops_does_nothing_without_pending_drops() {
+        let mut pending_drops = DropReport::default();
+        let mut last_drop_report = Instant::now() - DROP_REPORT_INTERVAL - Duration::from_millis(1);
+        let (on_event, events) = recording_channel();
+
+        maybe_report_drops(&mut pending_drops, &mut last_drop_report, &on_event, 9, 128, 3);
+
+        assert!(
+            events.lock().unwrap().is_empty(),
+            "rien à signaler sans perte en attente"
+        );
+    }
+
+    #[test]
+    fn maybe_report_drops_respects_the_rate_limit() {
+        let mut pending_drops = DropReport {
+            no_buffer: 1,
+            channel_full: 0,
+        };
+        let mut last_drop_report = Instant::now(); // rapport tout juste émis
+        let (on_event, events) = recording_channel();
+
+        maybe_report_drops(&mut pending_drops, &mut last_drop_report, &on_event, 9, 128, 3);
+
+        assert_eq!(
+            pending_drops.total(),
+            1,
+            "le compteur n'est pas remis à zéro avant l'intervalle minimal"
+        );
+        assert!(events.lock().unwrap().is_empty());
+    }
 }

--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -791,9 +791,15 @@ fn handle_capture_message(
         buffer_pool.put(pkt);
         match integration {
             Ok(()) => drain_and_finalize(worker, emitter, rx, buffer_pool, stop_flag, terminal),
-            Err(fatal) => {
-                stop_on_processing_fatal(worker, emitter, rx, buffer_pool, stop_flag, terminal, fatal)
-            }
+            Err(fatal) => stop_on_processing_fatal(
+                worker,
+                emitter,
+                rx,
+                buffer_pool,
+                stop_flag,
+                terminal,
+                fatal,
+            ),
         }
         return false;
     }
@@ -1520,7 +1526,10 @@ mod tests {
 
         drain_and_finalize(&mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
 
-        assert_eq!(worker.packets_integrated, 1, "le paquet en attente est drainé");
+        assert_eq!(
+            worker.packets_integrated, 1,
+            "le paquet en attente est drainé"
+        );
         assert!(
             !stop_flag.load(Ordering::Acquire),
             "le chemin nominal ne force pas l'arrêt lui-même"
@@ -1623,8 +1632,15 @@ mod tests {
         let msg = packet_message(&pool, &arp_frame());
         drop(tx); // canal vide et déconnecté : le drain qui suit se termine aussitôt
 
-        let keep_going =
-            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+        let keep_going = handle_capture_message(
+            msg,
+            &mut worker,
+            &mut emitter,
+            &rx,
+            &pool,
+            &stop_flag,
+            &terminal,
+        );
 
         assert!(!keep_going);
         assert_eq!(
@@ -1660,10 +1676,20 @@ mod tests {
         let (_tx, rx) = bounded::<CaptureMessage>(2);
         let msg = packet_message(&pool, &arp_frame());
 
-        let keep_going =
-            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+        let keep_going = handle_capture_message(
+            msg,
+            &mut worker,
+            &mut emitter,
+            &rx,
+            &pool,
+            &stop_flag,
+            &terminal,
+        );
 
-        assert!(keep_going, "traitement normal -> la boucle appelante continue");
+        assert!(
+            keep_going,
+            "traitement normal -> la boucle appelante continue"
+        );
         assert_eq!(worker.packets_integrated, 1);
         assert!(!stop_flag.load(Ordering::Acquire));
     }
@@ -1698,8 +1724,15 @@ mod tests {
         let msg = packet_message(&pool, &arp_frame());
         drop(tx);
 
-        let keep_going =
-            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+        let keep_going = handle_capture_message(
+            msg,
+            &mut worker,
+            &mut emitter,
+            &rx,
+            &pool,
+            &stop_flag,
+            &terminal,
+        );
 
         assert!(!keep_going);
         assert!(
@@ -1760,8 +1793,15 @@ mod tests {
         let msg = packet_message(&pool, &arp_frame());
         drop(tx);
 
-        let keep_going =
-            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+        let keep_going = handle_capture_message(
+            msg,
+            &mut worker,
+            &mut emitter,
+            &rx,
+            &pool,
+            &stop_flag,
+            &terminal,
+        );
 
         assert!(!keep_going);
         assert!(
@@ -1769,10 +1809,7 @@ mod tests {
             "canal IPC cassé -> arrêt de tout le pipeline"
         );
         assert!(
-            terminal
-                .preferred_reason()
-                .unwrap()
-                .contains("cassé"),
+            terminal.preferred_reason().unwrap().contains("cassé"),
             "la raison d'arrêt mentionne le canal IPC cassé"
         );
     }

--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -1593,4 +1593,196 @@ mod tests {
                 .contains("graphe")
         );
     }
+
+    /// handle_capture_message : arrêt déjà demandé quand le message arrive ->
+    /// le paquet est intégré silencieusement (pas d'émission IPC), puis le
+    /// reste du canal est drainé.
+    #[test]
+    fn handle_capture_message_ingests_silently_when_stop_already_requested() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let mut worker = PacketWorker::new(
+            Channel::new(|_| Ok(())),
+            11,
+            LinkType::ETHERNET,
+            flow_matrix,
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            drop_counters,
+            11,
+        );
+        let stop_flag = AtomicBool::new(true); // arrêt déjà demandé
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(2, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(2);
+        let msg = packet_message(&pool, &arp_frame());
+        drop(tx); // canal vide et déconnecté : le drain qui suit se termine aussitôt
+
+        let keep_going =
+            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(!keep_going);
+        assert_eq!(
+            worker.packets_integrated, 1,
+            "le paquet reçu pendant l'arrêt est tout de même intégré (#158)"
+        );
+    }
+
+    /// handle_capture_message : traitement normal (pas d'arrêt, canal IPC
+    /// vivant, plafond de flux non atteint) -> la boucle appelante continue.
+    #[test]
+    fn handle_capture_message_continues_on_normal_processing() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let mut worker = PacketWorker::new(
+            Channel::new(|_| Ok(())),
+            12,
+            LinkType::ETHERNET,
+            flow_matrix,
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            drop_counters,
+            12,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(2, 65_536);
+        let (_tx, rx) = bounded::<CaptureMessage>(2);
+        let msg = packet_message(&pool, &arp_frame());
+
+        let keep_going =
+            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(keep_going, "traitement normal -> la boucle appelante continue");
+        assert_eq!(worker.packets_integrated, 1);
+        assert!(!stop_flag.load(Ordering::Acquire));
+    }
+
+    /// handle_capture_message : une erreur fatale pendant process_packet
+    /// (verrou empoisonné) bascule sur stop_on_processing_fatal.
+    #[test]
+    fn handle_capture_message_stops_on_processing_fatal() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        poison(&flow_matrix);
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let (on_event, events) = recording_channel();
+        let mut worker = PacketWorker::new(
+            on_event,
+            13,
+            LinkType::ETHERNET,
+            Arc::clone(&flow_matrix),
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            Arc::clone(&drop_counters),
+            13,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(2, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(2);
+        let msg = packet_message(&pool, &arp_frame());
+        drop(tx);
+
+        let keep_going =
+            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(!keep_going);
+        assert!(
+            stop_flag.load(Ordering::Acquire),
+            "le chemin fatal force l'arrêt"
+        );
+        worker
+            .on_event
+            .send(CaptureEvent::Stopped {
+                session_id: worker.session_id,
+                reason: terminal.preferred_reason().unwrap(),
+            })
+            .unwrap();
+        let events = events.lock().unwrap();
+        let stopped = events
+            .iter()
+            .find(|event| event["event"] == "stopped")
+            .expect("le chemin fatal publie une raison d'arrêt observable");
+        assert!(
+            stopped["data"]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("matrice")
+        );
+    }
+
+    /// handle_capture_message : un canal IPC frontend cassé (flush échoue)
+    /// force l'arrêt du pipeline avec une raison explicite, sans passer par
+    /// stop_on_processing_fatal (ce n'est pas une erreur d'intégrité).
+    #[test]
+    fn handle_capture_message_stops_when_ipc_channel_is_broken() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let failing_channel =
+            Channel::new(|_| Err(tauri::Error::AssetNotFound("simulated IPC failure".into())));
+        let mut worker = PacketWorker::new(
+            failing_channel,
+            14,
+            LinkType::ETHERNET,
+            flow_matrix,
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        // Force le flush immédiat du batch de paquets dès le premier paquet,
+        // au lieu d'attendre PACKET_BATCH_INTERVAL.
+        worker.last_batch_flush = Instant::now() - PACKET_BATCH_INTERVAL - Duration::from_millis(1);
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            drop_counters,
+            14,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(2, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(2);
+        let msg = packet_message(&pool, &arp_frame());
+        drop(tx);
+
+        let keep_going =
+            handle_capture_message(msg, &mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(!keep_going);
+        assert!(
+            stop_flag.load(Ordering::Acquire),
+            "canal IPC cassé -> arrêt de tout le pipeline"
+        );
+        assert!(
+            terminal
+                .preferred_reason()
+                .unwrap()
+                .contains("cassé"),
+            "la raison d'arrêt mentionne le canal IPC cassé"
+        );
+    }
+
+    // Note : la branche « plafond MAX_LIVE_FLOWS atteint » de
+    // handle_capture_message n'a pas de test dédié -- worker.processed est
+    // réécrit par process_packet à partir du row_count() réel de la matrice
+    // (pas un compteur qu'on peut présigner), et peupler une matrice de
+    // 250 000 flux réels dans un test unitaire n'est pas praticable. Le reste
+    // de la fonction (stop_flag, keep_going, drain_and_finalize) est déjà
+    // couvert par les tests ci-dessus ; seul ce déclenchement précis reste
+    // non exercé directement.
 }

--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -1822,4 +1822,13 @@ mod tests {
     // de la fonction (stop_flag, keep_going, drain_and_finalize) est déjà
     // couvert par les tests ci-dessus ; seul ce déclenchement précis reste
     // non exercé directement.
+    //
+    // spawn_processing_thread lui-même (la boucle du thread spawné, pas les
+    // fonctions qu'il compose) reste aussi hors de portée d'un test direct :
+    // son paramètre `app: AppHandle` est câblé sur le runtime Wry concret,
+    // pas générique sur `R: Runtime`, donc incompatible avec l'AppHandle<MockRuntime>
+    // que produit `tauri::test::mock_builder()` (utilisé ailleurs dans ce
+    // fichier de commandes pour tester les handlers IPC complets). Rendre la
+    // fonction générique sur le runtime pour la rendre testable serait un
+    // changement de signature publique dépassant le périmètre de ce refactor.
 }

--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -743,6 +743,103 @@ fn stop_on_processing_fatal(
     emitter.send_final(worker);
 }
 
+/// Draine le canal restant puis finalise (flush des batches + stats
+/// finales), ou bascule sur le chemin d'arrêt fatal si le drainage échoue.
+/// Séquence identique répétée à chaque sortie de la boucle principale du
+/// thread de traitement (arrêt demandé, canal IPC frontend cassé, canal de
+/// capture déconnecté, plafond de flux atteint) : extraite pour éviter la
+/// duplication et garder la boucle appelante lisible.
+#[allow(clippy::too_many_arguments)]
+fn drain_and_finalize(
+    worker: &mut PacketWorker,
+    emitter: &mut StatsEmitter,
+    rx: &Receiver<CaptureMessage>,
+    buffer_pool: &PacketBufferPool,
+    stop_flag: &AtomicBool,
+    terminal: &TerminalState,
+) {
+    match worker.drain_channel(rx, buffer_pool) {
+        Ok(_) => {
+            let _ = worker.flush_batches();
+            emitter.send_final(worker);
+        }
+        Err(fatal) => {
+            stop_on_processing_fatal(worker, emitter, rx, buffer_pool, stop_flag, terminal, fatal);
+        }
+    }
+}
+
+/// Traite un message reçu du canal de capture pendant le fonctionnement
+/// normal (arrêt pas encore demandé au moment de la réception). Retourne
+/// `true` si la boucle principale doit continuer, `false` si elle doit
+/// s'arrêter -- dans ce cas, tout le nécessaire (drain, flush, stats
+/// finales ou chemin fatal) a déjà été fait par cette fonction.
+#[allow(clippy::too_many_arguments)]
+fn handle_capture_message(
+    CaptureMessage::Packet(pkt): CaptureMessage,
+    worker: &mut PacketWorker,
+    emitter: &mut StatsEmitter,
+    rx: &Receiver<CaptureMessage>,
+    buffer_pool: &PacketBufferPool,
+    stop_flag: &AtomicBool,
+    terminal: &TerminalState,
+) -> bool {
+    if stop_flag.load(Ordering::Acquire) {
+        // Arrêt reçu entre deux paquets : celui-ci et le reste du canal sont
+        // intégrés à la matrice avant de sortir.
+        let integration = worker.ingest_packet_silently(&pkt);
+        buffer_pool.put(pkt);
+        match integration {
+            Ok(()) => drain_and_finalize(worker, emitter, rx, buffer_pool, stop_flag, terminal),
+            Err(fatal) => {
+                stop_on_processing_fatal(worker, emitter, rx, buffer_pool, stop_flag, terminal, fatal)
+            }
+        }
+        return false;
+    }
+
+    let processing = worker.process_packet(&pkt);
+    buffer_pool.put(pkt);
+    let keep_going = match processing {
+        Ok(keep_going) => keep_going,
+        Err(fatal) => {
+            stop_on_processing_fatal(worker, emitter, rx, buffer_pool, stop_flag, terminal, fatal);
+            return false;
+        }
+    };
+    if !keep_going {
+        // Canal IPC vers le front cassé : sans arrêt explicite, le thread de
+        // capture continuerait seul à remplir le canal (capture fantôme). On
+        // stoppe tout le pipeline, en gardant les paquets déjà acceptés dans
+        // la matrice.
+        error!("Canal IPC frontend cassé : arrêt du pipeline de capture");
+        terminal
+            .record_autonomous("canal IPC frontend cassé : pipeline de capture arrêté".to_string());
+        stop_flag.store(true, Ordering::Release);
+        drain_and_finalize(worker, emitter, rx, buffer_pool, stop_flag, terminal);
+        return false;
+    }
+
+    if worker.processed >= MAX_LIVE_FLOWS {
+        // Plafond de flux atteint : arrêt propre et explicite plutôt qu'une
+        // éviction silencieuse (le relevé mentirait) ou un épuisement mémoire
+        // (#147). Comme à l'arrêt demandé, les paquets déjà acceptés dans le
+        // canal sont drainés vers la matrice : le dépassement du plafond est
+        // borné par la taille du canal, alors que les jeter serait une perte
+        // non comptée (#158).
+        error!("Plafond de {MAX_LIVE_FLOWS} flux atteint : arrêt de la capture");
+        terminal.record_autonomous(format!(
+            "plafond de {MAX_LIVE_FLOWS} flux atteint : capture arrêtée pour préserver la \
+             mémoire, le relevé reste fidèle jusqu'ici"
+        ));
+        stop_flag.store(true, Ordering::Release);
+        drain_and_finalize(worker, emitter, rx, buffer_pool, stop_flag, terminal);
+        return false;
+    }
+
+    true
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_processing_thread(
     rx: Receiver<CaptureMessage>,
@@ -793,127 +890,30 @@ pub fn spawn_processing_thread(
                 // sont intégrés à la matrice (fidélité du relevé), puis les
                 // derniers batches et le récapitulatif final partent vers le
                 // front en best-effort (#158).
-                match worker.drain_channel(&rx, &buffer_pool) {
-                    Ok(_) => {
-                        let _ = worker.flush_batches();
-                        emitter.send_final(&worker);
-                    }
-                    Err(fatal) => {
-                        stop_on_processing_fatal(
-                            &mut worker,
-                            &mut emitter,
-                            &rx,
-                            &buffer_pool,
-                            &stop_flag,
-                            &terminal,
-                            fatal,
-                        );
-                    }
-                }
+                drain_and_finalize(
+                    &mut worker,
+                    &mut emitter,
+                    &rx,
+                    &buffer_pool,
+                    &stop_flag,
+                    &terminal,
+                );
                 break;
             }
 
             let timeout = PACKET_BATCH_INTERVAL.saturating_sub(worker.last_batch_flush.elapsed());
             match rx.recv_timeout(timeout.max(Duration::from_millis(1))) {
-                Ok(CaptureMessage::Packet(pkt)) => {
-                    if stop_flag.load(Ordering::Acquire) {
-                        // Arrêt reçu entre deux paquets : celui-ci et le reste
-                        // du canal sont intégrés à la matrice avant de sortir.
-                        let integration = worker.ingest_packet_silently(&pkt);
-                        buffer_pool.put(pkt);
-                        let drained = integration
-                            .and_then(|_| worker.drain_channel(&rx, &buffer_pool).map(|_| ()));
-                        match drained {
-                            Ok(()) => {
-                                let _ = worker.flush_batches();
-                                emitter.send_final(&worker);
-                            }
-                            Err(fatal) => stop_on_processing_fatal(
-                                &mut worker,
-                                &mut emitter,
-                                &rx,
-                                &buffer_pool,
-                                &stop_flag,
-                                &terminal,
-                                fatal,
-                            ),
-                        }
-                        break;
-                    }
-
-                    let processing = worker.process_packet(&pkt);
-                    buffer_pool.put(pkt);
-                    let keep_going = match processing {
-                        Ok(keep_going) => keep_going,
-                        Err(fatal) => {
-                            stop_on_processing_fatal(
-                                &mut worker,
-                                &mut emitter,
-                                &rx,
-                                &buffer_pool,
-                                &stop_flag,
-                                &terminal,
-                                fatal,
-                            );
-                            break;
-                        }
-                    };
+                Ok(msg) => {
+                    let keep_going = handle_capture_message(
+                        msg,
+                        &mut worker,
+                        &mut emitter,
+                        &rx,
+                        &buffer_pool,
+                        &stop_flag,
+                        &terminal,
+                    );
                     if !keep_going {
-                        // Canal IPC vers le front cassé : sans arrêt explicite,
-                        // le thread de capture continuerait seul à remplir le
-                        // canal (capture fantôme). On stoppe tout le pipeline,
-                        // en gardant les paquets déjà acceptés dans la matrice.
-                        error!("Canal IPC frontend cassé : arrêt du pipeline de capture");
-                        terminal.record_autonomous(
-                            "canal IPC frontend cassé : pipeline de capture arrêté".to_string(),
-                        );
-                        stop_flag.store(true, Ordering::Release);
-                        match worker.drain_channel(&rx, &buffer_pool) {
-                            Ok(_) => {
-                                let _ = worker.flush_batches();
-                                emitter.send_final(&worker);
-                            }
-                            Err(fatal) => stop_on_processing_fatal(
-                                &mut worker,
-                                &mut emitter,
-                                &rx,
-                                &buffer_pool,
-                                &stop_flag,
-                                &terminal,
-                                fatal,
-                            ),
-                        }
-                        break;
-                    }
-
-                    if worker.processed >= MAX_LIVE_FLOWS {
-                        // Plafond de flux atteint : arrêt propre et explicite
-                        // plutôt qu'une éviction silencieuse (le relevé
-                        // mentirait) ou un épuisement mémoire (#147). Comme à
-                        // l'arrêt demandé, les paquets déjà acceptés dans le
-                        // canal sont drainés vers la matrice : le dépassement
-                        // du plafond est borné par la taille du canal, alors
-                        // que les jeter serait une perte non comptée (#158).
-                        error!("Plafond de {MAX_LIVE_FLOWS} flux atteint : arrêt de la capture");
-                        terminal.record_autonomous(format!(
-                            "plafond de {MAX_LIVE_FLOWS} flux atteint : capture arrêtée \
-                             pour préserver la mémoire, le relevé reste fidèle jusqu'ici"
-                        ));
-                        stop_flag.store(true, Ordering::Release);
-                        if let Err(fatal) = worker.drain_channel(&rx, &buffer_pool) {
-                            stop_on_processing_fatal(
-                                &mut worker,
-                                &mut emitter,
-                                &rx,
-                                &buffer_pool,
-                                &stop_flag,
-                                &terminal,
-                                fatal,
-                            );
-                            break;
-                        }
-                        let _ = worker.flush_batches();
-                        emitter.send_final(&worker);
                         break;
                     }
                 }
@@ -926,21 +926,14 @@ pub fn spawn_processing_thread(
                             "canal IPC frontend cassé : pipeline de capture arrêté".to_string(),
                         );
                         stop_flag.store(true, Ordering::Release);
-                        match worker.drain_channel(&rx, &buffer_pool) {
-                            Ok(_) => {
-                                let _ = worker.flush_batches();
-                                emitter.send_final(&worker);
-                            }
-                            Err(fatal) => stop_on_processing_fatal(
-                                &mut worker,
-                                &mut emitter,
-                                &rx,
-                                &buffer_pool,
-                                &stop_flag,
-                                &terminal,
-                                fatal,
-                            ),
-                        }
+                        drain_and_finalize(
+                            &mut worker,
+                            &mut emitter,
+                            &rx,
+                            &buffer_pool,
+                            &stop_flag,
+                            &terminal,
+                        );
                         break;
                     }
                 }
@@ -949,21 +942,14 @@ pub fn spawn_processing_thread(
                     // Le thread de capture est mort : on récupère ce qui reste
                     // dans le canal avant de sortir.
                     error!("Erreur réception canal : canal déconnecté");
-                    match worker.drain_channel(&rx, &buffer_pool) {
-                        Ok(_) => {
-                            let _ = worker.flush_batches();
-                            emitter.send_final(&worker);
-                        }
-                        Err(fatal) => stop_on_processing_fatal(
-                            &mut worker,
-                            &mut emitter,
-                            &rx,
-                            &buffer_pool,
-                            &stop_flag,
-                            &terminal,
-                            fatal,
-                        ),
-                    }
+                    drain_and_finalize(
+                        &mut worker,
+                        &mut emitter,
+                        &rx,
+                        &buffer_pool,
+                        &stop_flag,
+                        &terminal,
+                    );
                     break;
                 }
             }
@@ -1499,6 +1485,112 @@ mod tests {
         assert_eq!(
             final_stats["data"]["appDropped"], 1,
             "le paquet ayant révélé le poison reste comptabilisé"
+        );
+    }
+
+    /// drain_and_finalize (chemin nominal) : draine le canal restant puis
+    /// envoie les stats finales -- extrait de la boucle de
+    /// spawn_processing_thread, jamais appelé directement ailleurs.
+    #[test]
+    fn drain_and_finalize_success_sends_final_stats() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let (on_event, events) = recording_channel();
+        let mut worker = PacketWorker::new(
+            on_event,
+            7,
+            LinkType::ETHERNET,
+            flow_matrix,
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            Arc::clone(&drop_counters),
+            7,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(1, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(1);
+        tx.send(packet_message(&pool, &arp_frame())).unwrap();
+        drop(tx);
+
+        drain_and_finalize(&mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert_eq!(worker.packets_integrated, 1, "le paquet en attente est drainé");
+        assert!(
+            !stop_flag.load(Ordering::Acquire),
+            "le chemin nominal ne force pas l'arrêt lui-même"
+        );
+        let events = events.lock().unwrap();
+        assert!(
+            events.iter().any(|event| event["event"] == "stats"),
+            "les stats finales sont émises après un drainage réussi"
+        );
+    }
+
+    /// drain_and_finalize (chemin fatal) : un drainage qui échoue (verrou
+    /// empoisonné) bascule sur stop_on_processing_fatal au lieu d'envoyer les
+    /// stats finales du chemin nominal.
+    #[test]
+    fn drain_and_finalize_failure_takes_the_fatal_path() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        poison(&graph);
+        let (on_event, events) = recording_channel();
+        let mut worker = PacketWorker::new(
+            on_event,
+            8,
+            LinkType::ETHERNET,
+            Arc::clone(&flow_matrix),
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            Arc::clone(&drop_counters),
+            8,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(1, 65_536);
+        let (tx, rx) = bounded::<CaptureMessage>(1);
+        tx.send(packet_message(&pool, &arp_frame())).unwrap();
+        drop(tx);
+
+        drain_and_finalize(&mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(
+            stop_flag.load(Ordering::Acquire),
+            "le chemin fatal force l'arrêt via stop_on_processing_fatal"
+        );
+        assert_eq!(
+            flow_matrix.lock().unwrap().row_count(),
+            0,
+            "le graphe empoisonné bloque toute intégration"
+        );
+        worker
+            .on_event
+            .send(CaptureEvent::Stopped {
+                session_id: worker.session_id,
+                reason: terminal.preferred_reason().unwrap(),
+            })
+            .unwrap();
+        let events = events.lock().unwrap();
+        let stopped = events
+            .iter()
+            .find(|event| event["event"] == "stopped")
+            .expect("le chemin fatal publie une raison d'arrêt observable");
+        assert!(
+            stopped["data"]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("graphe")
         );
     }
 }


### PR DESCRIPTION
## Summary
The last 2 of the 8 CRITICAL cognitive-complexity findings from the SonarCloud cleanup (#176, #177, #178) — deliberately held back from those PRs and only attempted after explicit confirmation, since this is the live packet-capture and processing thread pipeline: the code SONAR's whole promise of capture fidelity depends on.

- **`processing.rs::spawn_processing_thread`** (complexity **56**) — its main loop repeated the exact same "drain the channel, then flush+send final stats or hand off to the fatal path" sequence at **6 different exit points**. Extracted into `drain_and_finalize()` + `handle_capture_message()` (the packet-arm's own two-stage logic). Every branch traced against the original to confirm identical control flow — see commit body for the specific MAX_LIVE_FLOWS-arm equivalence check.
- **`capture.rs::spawn_capture_thread_with_pool`** (complexity **34**) — buffer-get + try_send handling extracted into `forward_captured_packet()`, the rate-limited drop report into `maybe_report_drops()`. **Caught a real bug in my own first pass here**: calling the drop-report unconditionally after the extraction, when the original `break`s out of the Disconnected case before ever reaching that check. Fixed before it was ever committed — see commit body.

No behavior changes beyond that one self-caught-and-fixed ordering bug. Both commits add tests: 2 new ones directly against `drain_and_finalize`'s two branches (processing.rs already had 12 tests covering the primitives it composes), and 7 new ones for `capture.rs`, which had **zero tests before this PR**.

## What this couldn't verify
Neither file's spawned-thread loop can be driven end-to-end in this environment: no `sudo` for `setcap cap_net_raw,cap_net_admin` (required for live capture), and the X11 E2E harness's `--live-capture` scenario needs it. What *was* verified:
- `cargo build/test/clippy --locked` clean at every commit (183 tests passed, up from 174 before this PR)
- Release build (`--ci --no-sign --no-bundle`) + the maintained startup smoke test after both commits
- Manual line-by-line trace of every extracted branch against the original

If you want this validated against real traffic before merging, the steps are in `.claude/skills/verify/SKILL.md` §4 (apply capabilities post-build, run `--live-capture`) — I can walk through it with you if you'd rather do that than trust the trace + smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
