### PR TITLE
chore(sonar): classify src/tests as test code

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,5 +7,5 @@ sonar.sources=src,src-tauri/src
 sonar.tests=src/tests
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=**/node_modules/**,**/dist/**,**/target/**,**/.scannerwork/**,src-tauri/vendor/**,**/vendor/**,**/*.lock
+sonar.exclusions=**/node_modules/**,**/dist/**,**/target/**,**/.scannerwork/**,src-tauri/vendor/**,**/vendor/**,**/*.lock,src/tests/**
 sonar.javascript.lcov.reportPaths=coverage/frontend-lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.organization=sonar-team
 sonar.projectName=SONAR Desktop App
 
 sonar.sources=src,src-tauri/src
+sonar.tests=src/tests
 sonar.sourceEncoding=UTF-8
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/target/**,**/.scannerwork/**,src-tauri/vendor/**,**/vendor/**,**/*.lock


### PR DESCRIPTION
## Summary
sonar-project.properties had no `sonar.tests` declaration, so `src/tests` (21 Deno test files) got scanned as production source under `sonar.sources`. SonarCloud's TS/JS analyzer doesn't recognize `Deno.test()` as a test-framework call, so every one of those files — despite containing real, passing tests — got flagged BLOCKER "Add some tests to this file or delete it" (S2187). 20 files currently affected.

Added `sonar.tests=src/tests` to classify them correctly.

**This is experimental** — I can't run a SonarCloud analysis locally, only verify it once this merges and CI runs on `main`. Please check the dashboard afterward to confirm the S2187 BLOCKER count actually drops to 0 and there's no unexpected coverage/metric regression from the reclassification. If it doesn't help, easy to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)