### PR TITLE
refactor: close out the remaining CRITICAL complexity findings

### DIFF
--- a/src-tauri/src/state/capture/capture_handle/threads/capture.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/capture.rs
@@ -123,6 +123,24 @@ fn maybe_report_drops(
     *last_drop_report = Instant::now();
 }
 
+/// Rafraîchit les stats pcap partagées si l'intervalle de sondage est
+/// écoulé. Extrait de la boucle de capture pour éviter un if/if-let imbriqué
+/// répété à chaque tour (complexité cognitive).
+fn maybe_poll_capture_stats(
+    cap: &mut Capture<Active>,
+    shared_stats: &SharedCaptureStats,
+    last_stats_poll: &mut Instant,
+    stats_poll_interval: Duration,
+) {
+    if last_stats_poll.elapsed() < stats_poll_interval {
+        return;
+    }
+    *last_stats_poll = Instant::now();
+    if let Ok(stats) = cap.stats() {
+        shared_stats.store(stats);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_capture_thread_with_pool(
     tx: Sender<CaptureMessage>,
@@ -153,12 +171,12 @@ pub fn spawn_capture_thread_with_pool(
         let mut last_drop_report = Instant::now();
 
         while !stop_flag.load(Ordering::Acquire) {
-            if last_stats_poll.elapsed() >= stats_poll_interval {
-                last_stats_poll = Instant::now();
-                if let Ok(stats) = cap.stats() {
-                    shared_stats.store(stats);
-                }
-            }
+            maybe_poll_capture_stats(
+                &mut cap,
+                &shared_stats,
+                &mut last_stats_poll,
+                stats_poll_interval,
+            );
 
             match cap.next_packet() {
                 Ok(packet) => {

--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -846,6 +846,29 @@ fn handle_capture_message(
     true
 }
 
+/// Inactivité du canal : flush les batches en attente. Si le canal IPC
+/// frontend est cassé, arrête tout le pipeline (drain + finalize) et
+/// retourne `false` pour que la boucle appelante sorte. Extrait pour éviter
+/// un if imbriqué de plus dans la boucle principale.
+#[allow(clippy::too_many_arguments)]
+fn handle_receive_timeout(
+    worker: &mut PacketWorker,
+    emitter: &mut StatsEmitter,
+    rx: &Receiver<CaptureMessage>,
+    buffer_pool: &PacketBufferPool,
+    stop_flag: &AtomicBool,
+    terminal: &TerminalState,
+) -> bool {
+    if worker.flush_batches() {
+        return true;
+    }
+    error!("Canal IPC frontend cassé : arrêt du pipeline de capture");
+    terminal.record_autonomous("canal IPC frontend cassé : pipeline de capture arrêté".to_string());
+    stop_flag.store(true, Ordering::Release);
+    drain_and_finalize(worker, emitter, rx, buffer_pool, stop_flag, terminal);
+    false
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_processing_thread(
     rx: Receiver<CaptureMessage>,
@@ -925,21 +948,15 @@ pub fn spawn_processing_thread(
                 }
 
                 Err(RecvTimeoutError::Timeout) => {
-                    // Flush les batches restants après inactivité.
-                    if !worker.flush_batches() {
-                        error!("Canal IPC frontend cassé : arrêt du pipeline de capture");
-                        terminal.record_autonomous(
-                            "canal IPC frontend cassé : pipeline de capture arrêté".to_string(),
-                        );
-                        stop_flag.store(true, Ordering::Release);
-                        drain_and_finalize(
-                            &mut worker,
-                            &mut emitter,
-                            &rx,
-                            &buffer_pool,
-                            &stop_flag,
-                            &terminal,
-                        );
+                    let keep_going = handle_receive_timeout(
+                        &mut worker,
+                        &mut emitter,
+                        &rx,
+                        &buffer_pool,
+                        &stop_flag,
+                        &terminal,
+                    );
+                    if !keep_going {
                         break;
                     }
                 }

--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -1848,4 +1848,94 @@ mod tests {
     // fichier de commandes pour tester les handlers IPC complets). Rendre la
     // fonction générique sur le runtime pour la rendre testable serait un
     // changement de signature publique dépassant le périmètre de ce refactor.
+
+    /// handle_receive_timeout : le flush réussit (rien en attente ou canal
+    /// vivant) -> la boucle appelante continue, sans forcer l'arrêt.
+    #[test]
+    fn handle_receive_timeout_continues_when_flush_succeeds() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let mut worker = PacketWorker::new(
+            Channel::new(|_| Ok(())),
+            21,
+            LinkType::ETHERNET,
+            flow_matrix,
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            drop_counters,
+            21,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let pool = PacketBufferPool::new(2, 65_536);
+        let (_tx, rx) = bounded::<CaptureMessage>(2);
+
+        let keep_going =
+            handle_receive_timeout(&mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(keep_going);
+        assert!(!stop_flag.load(Ordering::Acquire));
+    }
+
+    /// handle_receive_timeout : le flush échoue (canal IPC cassé) -> arrêt de
+    /// tout le pipeline (drain + finalize), la boucle appelante doit sortir.
+    #[test]
+    fn handle_receive_timeout_stops_pipeline_when_flush_fails() {
+        let flow_matrix = Arc::new(Mutex::new(FlowMatrix::new()));
+        let graph = Arc::new(Mutex::new(GraphData::new()));
+        let failing_channel =
+            Channel::new(|_| Err(tauri::Error::AssetNotFound("simulated IPC failure".into())));
+        let mut worker = PacketWorker::new(
+            failing_channel,
+            22,
+            LinkType::ETHERNET,
+            flow_matrix,
+            graph,
+            TEST_DRAIN_STALL_BOUND,
+        );
+        let pool = PacketBufferPool::new(2, 65_536);
+        // Peuple packet_batch sans déclencher de flush (juste après
+        // construction, l'intervalle n'est pas écoulé) : handle_receive_timeout
+        // est le premier point qui tentera vraiment d'envoyer ce batch.
+        let msg = packet_message(&pool, &arp_frame());
+        let CaptureMessage::Packet(pkt) = msg;
+        assert!(worker.process_packet(&pkt).unwrap());
+        pool.put(pkt);
+
+        let drop_counters = Arc::new(AppDropCounters::default());
+        let mut emitter = StatsEmitter::new(
+            8,
+            Arc::new(SharedCaptureStats::default()),
+            drop_counters,
+            22,
+        );
+        let stop_flag = AtomicBool::new(false);
+        let terminal = TerminalState::default();
+        let (tx, rx) = bounded::<CaptureMessage>(2);
+        drop(tx);
+
+        let keep_going =
+            handle_receive_timeout(&mut worker, &mut emitter, &rx, &pool, &stop_flag, &terminal);
+
+        assert!(!keep_going);
+        assert!(
+            stop_flag.load(Ordering::Acquire),
+            "canal IPC cassé -> arrêt de tout le pipeline"
+        );
+        assert!(
+            terminal.preferred_reason().unwrap().contains("cassé"),
+            "la raison d'arrêt mentionne le canal IPC cassé"
+        );
+    }
+
+    // maybe_poll_capture_stats (capture.rs) reste hors de portée d'un test
+    // direct pour la même raison structurelle : elle prend un
+    // `&mut Capture<Active>`, une capture pcap réellement ouverte, non
+    // disponible dans cet environnement de test (pas de privilèges de
+    // capture live).
 }

--- a/src/store/capture.ts
+++ b/src/store/capture.ts
@@ -183,9 +183,7 @@ export const useCaptureStore = defineStore("capture", {
           for (const cb of this.graphUpdateListeners) cb(msg.data.update);
           break;
         case "graphBatch":
-          for (const update of msg.data.updates) {
-            for (const cb of this.graphUpdateListeners) cb(update);
-          }
+          this.notifyGraphUpdates(msg.data.updates);
           break;
         case "graphSnapshot":
           for (const cb of this.graphSnapshotListeners) cb(msg.data.graphData);
@@ -276,6 +274,9 @@ export const useCaptureStore = defineStore("capture", {
     // labels #157) : mêmes abonnés que le flux du channel de capture, mais
     // sans dépendre de l'existence d'un channel (hors capture).
     applyGraphUpdates(updates: GraphUpdate[]) {
+      this.notifyGraphUpdates(updates);
+    },
+    notifyGraphUpdates(updates: GraphUpdate[]) {
       for (const update of updates) {
         for (const cb of this.graphUpdateListeners) cb(update);
       }


### PR DESCRIPTION
## Summary
Follow-up to #178/#179 — 3 of the 5 CRITICAL cognitive-complexity findings that survived those PRs' refactors (each was only 1-3 points over the 15 threshold, confirmed against a real SonarCloud re-scan after #179 merged):

- **`store/capture.ts::dispatchCaptureEvent`** (16) — its `graphBatch` case had the only remaining nested double-loop. Extracted to `notifyGraphUpdates()`, reused in `applyGraphUpdates()` too (same body, was duplicated).
- **`capture.rs::spawn_capture_thread_with_pool`** (18) — the periodic pcap-stats poll was the last inline nested block. Extracted to `maybe_poll_capture_stats()`.
- **`processing.rs::spawn_processing_thread`** (16) — the `Err(RecvTimeoutError::Timeout)` arm's flush-or-teardown logic was the last inline nested block. Extracted to `handle_receive_timeout()`.

Caught and fixed my own mistake in the second commit: moving `maybe_poll_capture_stats` in ahead of `spawn_capture_thread_with_pool` pushed `#[allow(clippy::too_many_arguments)]` onto the wrong function — clippy re-run caught it immediately (warned on the 11-arg function, no longer suppressed), fixed before committing.

**Not addressed here, with reasoning:**
- `processing.rs::process_packet` (16) — its complexity comes almost entirely from `#[cfg(feature = "capture_timing")]` conditional-compilation blocks. SonarCloud's static analysis sees both the timing and non-timing code paths at once; no single real build ever has this complexity. Not a real hot-path issue, and touching the timing instrumentation for a linter score wasn't worth the risk.
- `conflicts.rs::verif_labels_conflicts` (17, test-only, `#[cfg(test)]`) — already had one extraction in #178 (18→17); the remaining complexity is the O(n²) nested-loop *structure* itself (not what's inside it), which would need an algorithmic change (group-by-key instead of pairwise compare) to reduce further. Legacy test-only code per its own comment ("ne sert plus qu'aux tests") — not worth restructuring for a 1-point delta.

## Test plan
- [x] `deno task typecheck`/`lint`/`test` (172 passed) after the store commit
- [x] `cargo build/test (187 passed)/clippy/fmt --check` clean after each Rust commit
- [x] Release build + startup smoke test after the capture.rs and processing.rs commits (still the live-capture thread code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
