### PR TITLE
refactor(capture): flatten spawn_processing_thread's last nested breaks

### DIFF
--- a/src-tauri/src/state/capture/capture_handle/threads/processing.rs
+++ b/src-tauri/src/state/capture/capture_handle/threads/processing.rs
@@ -931,36 +931,24 @@ pub fn spawn_processing_thread(
             }
 
             let timeout = PACKET_BATCH_INTERVAL.saturating_sub(worker.last_batch_flush.elapsed());
-            match rx.recv_timeout(timeout.max(Duration::from_millis(1))) {
-                Ok(msg) => {
-                    let keep_going = handle_capture_message(
-                        msg,
-                        &mut worker,
-                        &mut emitter,
-                        &rx,
-                        &buffer_pool,
-                        &stop_flag,
-                        &terminal,
-                    );
-                    if !keep_going {
-                        break;
-                    }
-                }
-
-                Err(RecvTimeoutError::Timeout) => {
-                    let keep_going = handle_receive_timeout(
-                        &mut worker,
-                        &mut emitter,
-                        &rx,
-                        &buffer_pool,
-                        &stop_flag,
-                        &terminal,
-                    );
-                    if !keep_going {
-                        break;
-                    }
-                }
-
+            let keep_going = match rx.recv_timeout(timeout.max(Duration::from_millis(1))) {
+                Ok(msg) => handle_capture_message(
+                    msg,
+                    &mut worker,
+                    &mut emitter,
+                    &rx,
+                    &buffer_pool,
+                    &stop_flag,
+                    &terminal,
+                ),
+                Err(RecvTimeoutError::Timeout) => handle_receive_timeout(
+                    &mut worker,
+                    &mut emitter,
+                    &rx,
+                    &buffer_pool,
+                    &stop_flag,
+                    &terminal,
+                ),
                 Err(RecvTimeoutError::Disconnected) => {
                     // Le thread de capture est mort : on récupère ce qui reste
                     // dans le canal avant de sortir.
@@ -973,8 +961,11 @@ pub fn spawn_processing_thread(
                         &stop_flag,
                         &terminal,
                     );
-                    break;
+                    false
                 }
+            };
+            if !keep_going {
+                break;
             }
 
             emitter.tick(rx.len(), &worker);


### PR DESCRIPTION
## Summary
Last CRITICAL complexity finding this session that's actually fixable — confirmed against a real SonarCloud re-scan after #181 merged, `spawn_processing_thread` was still at 16 (1 over threshold) despite the earlier `handle_receive_timeout` extraction: each of its 3 `match` arms on `rx.recv_timeout()` had its own identical `if !keep_going { break }`. Turned the match into an expression yielding `keep_going` directly, one `if` after it instead of three.

No behavior change — same three outcomes, same downstream calls, purely a control-flow shape change.

**Still not addressed** (unchanged from #181's reasoning, still the right call): `processing.rs::process_packet` (complexity inflated by `#[cfg(feature = "capture_timing")]` blocks Sonar's static analysis sees both sides of) and `conflicts.rs::verif_labels_conflicts` (test-only, complexity is the O(n²) loop structure itself).

## Test plan
- [x] `cargo build/test (189 passed)/clippy/fmt --check` clean
- [x] Release build + startup smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)