### PR TITLE
fix(deb): déclarer libpcap0.8 dans les Depends du .deb

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -93,6 +93,14 @@
       }
     },
 
+    "linux": {
+      "deb": {
+        "depends": [
+          "libpcap0.8"
+        ]
+      }
+    },
+
     "resources": {
       "resources/labels.csv": "resources/labels.csv"
     }


### PR DESCRIPTION
Closes #175.

## Quoi

Le binaire `sonar` est lié dynamiquement à `libpcap.so.0.8` (dépendance ELF `NEEDED`), mais le `control` du `.deb` généré ne déclarait que `libwebkit2gtk-4.1-0, libgtk-3-0` : sur une machine sans libpcap préinstallé, l'exécutable ne se chargeait pas du tout.

Ajout d'une section `bundle.linux.deb.depends` avec `libpcap0.8` (nom du paquet runtime Debian trixie/Ubuntu). Point d'implémentation vérifié sur le `.deb` produit : le bundler Tauri **ajoute ses dépendances par défaut après** celles déclarées — redéclarer webkit/gtk crée des doublons dans `Depends:`, donc seule `libpcap0.8` est listée.

## Preuves

`Depends:` du `.deb` construit : `libpcap0.8, libwebkit2gtk-4.1-0, libgtk-3-0`

Reproduction de l'issue rejouée en conteneur Debian trixie vierge :
```
apt-get install -y ./sonar_4.10.0_amd64.deb   # tire libpcap0.8
sonar --sonar-smoke-test
# SONAR_STARTUP_VALIDATION=OK, exit=0
```
(avant le correctif : `error while loading shared libraries: libpcap.so.0.8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)