### PR TITLE
feat(154): identité de nœud (vlan, ip) et ids stables — sonar-flows-core 0.5.0

### DIFF
--- a/project_management/cadrage_identite_actif_154.md
+++ b/project_management/cadrage_identite_actif_154.md
@@ -104,7 +104,11 @@ même mécanique de PR que #183.
    même paquet peut être vu par plusieurs capteurs — mettre le capteur
    dans la clé empêcherait de reconnaître ce recouvrement (dédup et
    corrélation inter-capteurs).
-3. Tranche 3 : périmètre en cours de discussion (#154 vs epic #164).
+3. **Tranche 3 déplacée dans l'epic #164.** La corrélation explicite
+   d'actifs (fusion manuelle tracée et réversible de deux nœuds) relève du
+   même modèle que l'inventaire d'actifs et la baseline : la construire
+   dans #154 ferait deux modèles pour la même chose. #154 se ferme sur
+   les tranches 1 et 2.
 4. **Saisie du site/capteur : au moment de l'arrêt (stop) ou de
    l'enregistrement, à la Wireshark** — pas de configuration a priori.
    Implication : un dialogue de qualification du relevé au stop/save
@@ -119,3 +123,27 @@ Le dépôt source de sonar-flows-core est ce même repo :
 fuzz), publié sur crates.io par `.github/workflows/publish-crates.yml`.
 Cycle tranche 1 : PR sur `sonar-rust` (0.5.0) → publication → re-vendor
 `src-tauri` → vet, comme pour packet_parser 9 (PR #183).
+
+### Tranche 1 implémentée — 04/08/2026 (sonar-flows-core 0.5.0)
+
+- Clé de nœud `(vlan, ip)` (`l3_node_key`), repli L2 `(vlan, mac)` ;
+  hors trame taguée la clé reste l'IP nue (continuité des relevés).
+- Ids de nœuds **et** d'arêtes stables : hash FNV-1a de la clé
+  d'identité (le même hachage que `encap_id`), plus de compteurs
+  globaux — snapshots déterministes.
+- `Node.vlan_id: Option<u16>` et `Node.duplicate_ip: bool` (IP portée
+  par plusieurs VLAN : signalée via un index IP → nœuds, jamais
+  fusionnée). Contrat TS à régénérer côté desktop au re-vendoring.
+- Labels : `update_node_label` retourne désormais `Vec<GraphUpdate>`
+  (une (mac, ip) sur deux VLAN étiquette les deux nœuds) et matche
+  toutes les MAC observées ; `refresh_labels` essaie le résolveur sur
+  chaque MAC observée. **Précision de périmètre** : le palier de
+  précédence `(vlan, mac, ip)` exact demanderait le VLAN dans le store
+  de labels donc dans labels.csv — contradictoire avec « ne touche pas
+  au CSV » ; il part en tranche 2 avec le versionnage des formats.
+- sonar-flows-cli : le départage des égalités de trafic de l'export
+  Graphviz tranche sur l'identité lisible (IP/MAC), plus sur l'id.
+- Ripple attendu au re-vendoring dans src-tauri : signatures
+  `Node::new`/`Edge::new` (clé en premier argument), retour de
+  `update_node_label` (labels/commands.rs), nouveaux champs dans le
+  contrat d'événements.

--- a/sonar-rust/Cargo.lock
+++ b/sonar-rust/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sonar-flows-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "csv",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "sonar-flows-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "csv",

--- a/sonar-rust/Cargo.toml
+++ b/sonar-rust/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/Sonar-team/Sonar_desktop_app"
 rust-version = "1.97.1"
-version = "0.4.0"
+version = "0.5.0"
 
 [workspace.dependencies]
 chrono = "0.4.45"
@@ -22,7 +22,7 @@ log = "0.4.33"
 packet_parser = "9.0.0"
 pcap = "2.4.0"
 serde = { version = "1", features = ["derive"] }
-sonar-flows-core = { path = "crates/sonar-flows-core", version = "0.4.0" }
+sonar-flows-core = { path = "crates/sonar-flows-core", version = "0.5.0" }
 thiserror = "2.0.19"
 
 # Même politique que src-tauri : pas de panic évitable en code de prod.

--- a/sonar-rust/crates/sonar-flows-cli/src/graphviz.rs
+++ b/sonar-rust/crates/sonar-flows-cli/src/graphviz.rs
@@ -89,7 +89,14 @@ fn filtered_edges<'a>(graph: &'a GraphData, options: &GraphOptions) -> Vec<&'a E
         .collect();
 
     // Les nœuds les plus actifs sont retenus, puis on garde le sous-graphe
-    // induit. La clé textuelle tranche les égalités de façon stable.
+    // induit. Les égalités de trafic sont tranchées par l'identité lisible
+    // (IP/MAC) : les ids de nœuds sont des hash opaques depuis
+    // sonar-flows-core 0.5 et leur ordre lexicographique n'a aucun sens.
+    let nodes_by_id: HashMap<&str, &Node> = graph
+        .nodes
+        .values()
+        .map(|node| (node.id.as_str(), node))
+        .collect();
     let mut traffic: HashMap<&str, u64> = HashMap::new();
     for edge in &candidates {
         for node_id in [&edge.source, &edge.target] {
@@ -99,7 +106,12 @@ fn filtered_edges<'a>(graph: &'a GraphData, options: &GraphOptions) -> Vec<&'a E
     }
     let mut ranked_nodes: Vec<(&str, u64)> = traffic.into_iter().collect();
     ranked_nodes.sort_by(|(id_a, bytes_a), (id_b, bytes_b)| {
-        bytes_b.cmp(bytes_a).then_with(|| id_a.cmp(id_b))
+        let key_a = nodes_by_id.get(id_a).map_or(*id_a, |n| stable_node_id(n));
+        let key_b = nodes_by_id.get(id_b).map_or(*id_b, |n| stable_node_id(n));
+        bytes_b
+            .cmp(bytes_a)
+            .then_with(|| key_a.cmp(key_b))
+            .then_with(|| id_a.cmp(id_b))
     });
     let retained: HashSet<&str> = ranked_nodes
         .into_iter()

--- a/sonar-rust/crates/sonar-flows-core/src/graph.rs
+++ b/sonar-rust/crates/sonar-flows-core/src/graph.rs
@@ -1,11 +1,11 @@
-//! Graphe réseau : nœuds (équipements identifiés par IP ou MAC) et arêtes
-//! (conversations par protocole), construit incrémentalement pendant la
-//! capture ou l'import et synchronisé avec le frontend par `GraphUpdate`.
+//! Graphe réseau : nœuds (équipements identifiés par (VLAN, IP) ou
+//! (VLAN, MAC)) et arêtes (conversations par protocole), construit
+//! incrémentalement pendant la capture ou l'import et synchronisé avec le
+//! frontend par `GraphUpdate`.
 
 use packet_parser::{IpType, owned::PacketFlowOwned};
 use serde::Serialize;
 use std::collections::{BTreeSet, HashMap};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::link::LinkView;
 use crate::matrix::FlowMatrix;
@@ -15,10 +15,42 @@ use crate::matrix::is_non_unicast_mac;
 /// reçoit soit des updates incrémentales, soit un snapshot entier.
 #[derive(Serialize, Default, Debug)]
 pub struct GraphData {
-    // clé = IP (stringifiée) ou "mac:XX:XX:..."
+    // clé = identité (VLAN, IP) ou (VLAN, MAC), cf. l3_node_key/l2_node_key
     pub nodes: HashMap<String, Node>,
     // clé = "a_id:b_id:protocol" (canonique: a_id <= b_id)
     pub edges: HashMap<String, Edge>,
+    // index IP -> clés de nœuds L3 : détection « même IP sur plusieurs
+    // VLAN » (anomalie duplicate_ip) sans balayage du graphe (#154).
+    #[serde(skip)]
+    ip_index: HashMap<String, BTreeSet<String>>,
+}
+
+/// Clé d'identité d'un nœud L3 : le VLAN 802.1Q fait partie de l'identité
+/// observée (#154) — la même IP sur deux VLAN est deux actifs distincts.
+/// Hors trame taguée, la clé reste l'IP nue (continuité avec les relevés
+/// existants).
+fn l3_node_key(vlan_id: Option<u16>, ip: &str) -> String {
+    match vlan_id {
+        None => ip.to_string(),
+        Some(id) => format!("vlan{id}:{ip}"),
+    }
+}
+
+/// Clé d'identité d'un nœud L2 (repli sans IP valide) : (VLAN, MAC).
+fn l2_node_key(vlan_id: Option<u16>, mac: &str) -> String {
+    match vlan_id {
+        None => format!("mac:{mac}"),
+        Some(id) => format!("vlan{id}:mac:{mac}"),
+    }
+}
+
+/// Identifiant stable d'un nœud ou d'une arête : hash FNV-1a de sa clé
+/// d'identité (le même hachage, stable entre builds, que `encap_id`).
+/// Remplace les compteurs globaux (#154) : le même relevé rouvert redonne
+/// les mêmes ids — prérequis des snapshots déterministes et de la future
+/// corrélation d'actifs (#164).
+fn stable_id(key: &str) -> String {
+    format!("{:016x}", crate::packet::fnv1a(key.as_bytes()))
 }
 
 #[derive(Clone, Serialize, Debug)]
@@ -33,9 +65,6 @@ pub enum GraphUpdate {
     #[serde(rename = "edgeUpdated")]
     EdgeUpdated(Edge),
 }
-
-static NODE_COUNTER: AtomicU64 = AtomicU64::new(1);
-static EDGE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Accumulateur d'updates graphe avec coalescence par entité : au sein d'une
 /// fenêtre de batch, une seule entrée par nœud/arête (la dernière valeur gagne,
@@ -116,6 +145,8 @@ impl GraphUpdateBatch {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct Node {
+    /// Id stable dérivé de la clé d'identité ([`stable_id`]) : identique
+    /// d'une exécution à l'autre pour le même relevé (#154).
     pub id: String,
     pub name: String,  // l’IP sous forme de string (ou MAC)
     pub color: String, // stockée en String côté struct (UI-friendly)
@@ -126,30 +157,39 @@ pub struct Node {
     /// usurpation ARP…) : le front la signale visuellement.
     pub macs: Vec<String>,
     pub ip: String,
+    /// VLAN 802.1Q du nœud (`None` hors trame taguée) : fait partie de la
+    /// clé d'identité — la même IP sur deux VLAN est deux nœuds (#154).
+    pub vlan_id: Option<u16>,
+    /// Vrai quand la même IP est portée par plusieurs nœuds (VLAN
+    /// différents) : anomalie signalée visuellement, jamais fusionnée (#154).
+    pub duplicate_ip: bool,
     pub label: Option<String>,
 }
 
 impl Node {
     pub fn new(
+        key: &str,
         name: String,
         mac: String,
         color: &'static str,
         ip: String,
+        vlan_id: Option<u16>,
         label: Option<String>,
     ) -> Self {
-        let id = NODE_COUNTER.fetch_add(1, Ordering::SeqCst);
         let macs = if mac.is_empty() || is_non_unicast_mac(&mac) {
             Vec::new()
         } else {
             vec![mac.clone()]
         };
         Self {
-            id: id.to_string(),
+            id: stable_id(key),
             name,
             color: color.to_string(),
             mac,
             macs,
             ip,
+            vlan_id,
+            duplicate_ip: false,
             label,
         }
     }
@@ -207,10 +247,11 @@ pub struct Edge {
 }
 
 impl Edge {
-    pub fn new(source: String, target: String) -> Self {
-        let id = EDGE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    /// `key` : clé non orientée `{A,B,proto}` ([`undirected_edge_key`]) dont
+    /// dérive l'id stable — les compteurs globaux ont disparu (#154).
+    pub fn new(key: &str, source: String, target: String) -> Self {
         Self {
-            id: id.to_string(),
+            id: stable_id(key),
             source,
             target,
             label: String::new(),
@@ -333,7 +374,6 @@ impl GraphData {
         bytes: u64,
         encap_ids: &[u64],
     ) -> Vec<GraphUpdate> {
-        use std::collections::hash_map::Entry;
         let mut updates = Vec::new();
         let link = LinkView::of(&packet.data_link);
 
@@ -346,117 +386,34 @@ impl GraphData {
             let src_type = internet.ip_source_type.as_ref();
             let dst_type = internet.ip_destination_type.as_ref();
             if is_valid_ip(src_type) && is_valid_ip(dst_type) {
-                let src_color = color_of(src_type);
-                let dst_color = color_of(dst_type);
+                let src_node_id = self.ensure_l3_node(
+                    link.vlan_id,
+                    &src_ip.to_string(),
+                    &link.source_mac,
+                    color_of(src_type),
+                    source_label,
+                    &mut updates,
+                );
+                let dst_node_id = self.ensure_l3_node(
+                    link.vlan_id,
+                    &dst_ip.to_string(),
+                    &link.destination_mac,
+                    color_of(dst_type),
+                    destination_label,
+                    &mut updates,
+                );
 
-                let src_ip_str = src_ip.to_string();
-                let dst_ip_str = dst_ip.to_string();
-
-                // Nœud source
-                let src_node_id = match self.nodes.entry(src_ip_str.clone()) {
-                    Entry::Occupied(mut e) => {
-                        maybe_update_node_label(e.get_mut(), source_label.clone(), &mut updates);
-                        record_observed_mac(e.get_mut(), &link.source_mac, &mut updates);
-                        e.get().id.clone()
-                    }
-                    Entry::Vacant(v) => {
-                        let node = Node::new(
-                            src_ip_str.clone(),
-                            link.source_mac.clone(),
-                            src_color,
-                            src_ip_str.clone(),
-                            source_label.clone(),
-                        );
-                        let node_id = node.id.clone();
-                        v.insert(node.clone());
-                        updates.push(GraphUpdate::NewNode(node));
-                        node_id
-                    }
-                };
-
-                // Nœud destination
-                let dst_node_id = match self.nodes.entry(dst_ip_str.clone()) {
-                    Entry::Occupied(mut e) => {
-                        maybe_update_node_label(
-                            e.get_mut(),
-                            destination_label.clone(),
-                            &mut updates,
-                        );
-                        record_observed_mac(e.get_mut(), &link.destination_mac, &mut updates);
-                        e.get().id.clone()
-                    }
-                    Entry::Vacant(v) => {
-                        let node = Node::new(
-                            dst_ip_str.clone(),
-                            link.destination_mac.clone(),
-                            dst_color,
-                            dst_ip_str.clone(),
-                            destination_label.clone(),
-                        );
-                        let node_id = node.id.clone();
-                        v.insert(node.clone());
-                        updates.push(GraphUpdate::NewNode(node));
-                        node_id
-                    }
-                };
-
-                let protocol = best_protocol_label(packet);
-
-                // Clé non orientée : {A,B,proto} indépendamment du sens.
-                let edge_key = undirected_edge_key(&src_node_id, &dst_node_id, &protocol);
-
-                match self.edges.get_mut(&edge_key) {
-                    Some(edge) => {
-                        // Arête existe déjà (A—B:proto).
-                        let mut notify = false;
-
-                        // L'arête est stockée dans le sens du premier paquet
-                        // observé : bidir passe à vrai seulement quand le sens
-                        // courant en diffère réellement.
-                        if !edge.bidir && edge.source != src_node_id {
-                            edge.bidir = true;
-                            notify = true;
-                        }
-
-                        if accumulate_traffic(edge, packets, bytes) {
-                            notify = true;
-                        }
-
-                        if merge_encap_ids(edge, encap_ids) {
-                            notify = true;
-                        }
-
-                        // Chaque service observé s'ajoute à l'arête : le
-                        // premier couple de ports ne masque plus les autres
-                        // services (#154), et les ports éphémères ne polluent
-                        // pas la liste (port « service » + plage dynamique).
-                        if edge.record_service_port(
-                            packet.transport.as_ref().and_then(|t| t.source_port),
-                            packet.transport.as_ref().and_then(|t| t.destination_port),
-                        ) {
-                            notify = true;
-                        }
-
-                        if notify {
-                            updates.push(GraphUpdate::EdgeUpdated(edge.clone()));
-                        }
-                    }
-                    None => {
-                        // Première observation de {A,B,proto} : l'arête est
-                        // créée dans le sens réellement observé (la flèche du
-                        // rendu reflète le premier paquet).
-                        let mut edge = Edge::new(src_node_id.clone(), dst_node_id.clone())
-                            .with_label(protocol)
-                            .with_ports(
-                                packet.transport.as_ref().and_then(|t| t.source_port),
-                                packet.transport.as_ref().and_then(|t| t.destination_port),
-                            )
-                            .with_traffic(packets, bytes);
-                        merge_encap_ids(&mut edge, encap_ids);
-                        self.edges.insert(edge_key, edge.clone());
-                        updates.push(GraphUpdate::NewEdge(edge));
-                    }
-                }
+                self.upsert_edge(
+                    &src_node_id,
+                    &dst_node_id,
+                    best_protocol_label(packet),
+                    packet.transport.as_ref().and_then(|t| t.source_port),
+                    packet.transport.as_ref().and_then(|t| t.destination_port),
+                    packets,
+                    bytes,
+                    encap_ids,
+                    &mut updates,
+                );
 
                 return updates; // L3 traité
             }
@@ -465,23 +422,102 @@ impl GraphData {
         // ===============================
         // 2) Fallback L2 (MAC-only)
         // ===============================
+        let src_node_id = self.ensure_l2_node(link.vlan_id, &link.source_mac, &mut updates);
+        let dst_node_id = self.ensure_l2_node(link.vlan_id, &link.destination_mac, &mut updates);
+
+        self.upsert_edge(
+            &src_node_id,
+            &dst_node_id,
+            link.protocol.clone(),
+            None, // pas de ports en L2
+            None,
+            packets,
+            bytes,
+            encap_ids,
+            &mut updates,
+        );
+
+        updates
+    }
+
+    /// Retrouve ou crée le nœud L3 d'identité `(vlan, ip)` et retourne son id.
+    /// À la création, si d'autres nœuds portent déjà la même IP (autres VLAN),
+    /// tous les porteurs sont marqués `duplicate_ip` : l'anomalie est
+    /// signalée, jamais fusionnée (#154).
+    fn ensure_l3_node(
+        &mut self,
+        vlan_id: Option<u16>,
+        ip: &str,
+        mac: &str,
+        color: &'static str,
+        label: Option<String>,
+        updates: &mut Vec<GraphUpdate>,
+    ) -> String {
+        use std::collections::hash_map::Entry;
+
+        let key = l3_node_key(vlan_id, ip);
+        let (node_id, created) = match self.nodes.entry(key.clone()) {
+            Entry::Occupied(mut e) => {
+                maybe_update_node_label(e.get_mut(), label, updates);
+                record_observed_mac(e.get_mut(), mac, updates);
+                (e.get().id.clone(), false)
+            }
+            Entry::Vacant(v) => {
+                let node = Node::new(
+                    &key,
+                    ip.to_string(),
+                    mac.to_string(),
+                    color,
+                    ip.to_string(),
+                    vlan_id,
+                    label,
+                );
+                let node_id = node.id.clone();
+                v.insert(node.clone());
+                updates.push(GraphUpdate::NewNode(node));
+                (node_id, true)
+            }
+        };
+
+        if created {
+            let siblings = self.ip_index.entry(ip.to_string()).or_default();
+            siblings.insert(key);
+            if siblings.len() >= 2 {
+                for sibling_key in siblings.clone() {
+                    if let Some(node) = self.nodes.get_mut(&sibling_key)
+                        && !node.duplicate_ip
+                    {
+                        node.duplicate_ip = true;
+                        updates.push(GraphUpdate::NodeUpdated(node.clone()));
+                    }
+                }
+            }
+        }
+
+        node_id
+    }
+
+    /// Retrouve ou crée le nœud L2 d'identité `(vlan, mac)` et retourne son id.
+    fn ensure_l2_node(
+        &mut self,
+        vlan_id: Option<u16>,
+        mac: &str,
+        updates: &mut Vec<GraphUpdate>,
+    ) -> String {
+        use std::collections::hash_map::Entry;
         const L2_COLOR: &str = "#00BCD4";
 
-        let src_mac = link.source_mac.clone();
-        let dst_mac = link.destination_mac.clone();
-
-        let src_key = format!("mac:{src_mac}");
-        let dst_key = format!("mac:{dst_mac}");
-
-        // Nœud source (MAC)
-        let src_node_id = match self.nodes.entry(src_key.clone()) {
+        let key = l2_node_key(vlan_id, mac);
+        match self.nodes.entry(key.clone()) {
             Entry::Occupied(e) => e.get().id.clone(),
             Entry::Vacant(v) => {
                 let node = Node::new(
-                    src_mac.clone(),
-                    src_mac.clone(),
+                    &key,
+                    mac.to_string(),
+                    mac.to_string(),
                     L2_COLOR,
                     "".to_string(),
+                    vlan_id,
                     None,
                 );
                 let node_id = node.id.clone();
@@ -489,94 +525,117 @@ impl GraphData {
                 updates.push(GraphUpdate::NewNode(node));
                 node_id
             }
-        };
+        }
+    }
 
-        // Nœud destination (MAC)
-        let dst_node_id = match self.nodes.entry(dst_key.clone()) {
-            Entry::Occupied(e) => e.get().id.clone(),
-            Entry::Vacant(v) => {
-                let node = Node::new(
-                    dst_mac.clone(),
-                    dst_mac.clone(),
-                    L2_COLOR,
-                    "".to_string(),
-                    None,
-                );
-                let node_id = node.id.clone();
-                v.insert(node.clone());
-                updates.push(GraphUpdate::NewNode(node));
-                node_id
-            }
-        };
-
-        let l2_proto = link.protocol.clone();
-        let edge_key = undirected_edge_key(&src_node_id, &dst_node_id, &l2_proto);
+    /// Retrouve ou crée l'arête non orientée `{A,B,proto}` et y agrège le
+    /// trafic. L'arête est stockée dans le sens du premier paquet observé :
+    /// `bidir` ne passe à vrai que quand le sens courant en diffère. Chaque
+    /// service observé s'ajoute à la liste des ports (#154), les éphémères
+    /// levant seulement `has_dynamic_ports`.
+    #[allow(clippy::too_many_arguments)]
+    fn upsert_edge(
+        &mut self,
+        src_node_id: &str,
+        dst_node_id: &str,
+        protocol: String,
+        source_port: Option<u16>,
+        destination_port: Option<u16>,
+        packets: u64,
+        bytes: u64,
+        encap_ids: &[u64],
+        updates: &mut Vec<GraphUpdate>,
+    ) {
+        let edge_key = undirected_edge_key(src_node_id, dst_node_id, &protocol);
 
         match self.edges.get_mut(&edge_key) {
             Some(edge) => {
                 let mut notify = false;
+
                 if !edge.bidir && edge.source != src_node_id {
                     edge.bidir = true;
                     notify = true;
                 }
+
                 if accumulate_traffic(edge, packets, bytes) {
                     notify = true;
                 }
+
                 if merge_encap_ids(edge, encap_ids) {
                     notify = true;
                 }
+
+                if edge.record_service_port(source_port, destination_port) {
+                    notify = true;
+                }
+
                 if notify {
                     updates.push(GraphUpdate::EdgeUpdated(edge.clone()));
                 }
             }
             None => {
-                let mut edge = Edge::new(src_node_id.clone(), dst_node_id.clone())
-                    .with_label(l2_proto)
-                    .with_ports(None, None) // pas de ports en L2
-                    .with_traffic(packets, bytes);
+                // Première observation de {A,B,proto} : l'arête est créée
+                // dans le sens réellement observé (la flèche du rendu
+                // reflète le premier paquet).
+                let mut edge =
+                    Edge::new(&edge_key, src_node_id.to_string(), dst_node_id.to_string())
+                        .with_label(protocol)
+                        .with_ports(source_port, destination_port)
+                        .with_traffic(packets, bytes);
                 merge_encap_ids(&mut edge, encap_ids);
                 self.edges.insert(edge_key, edge.clone());
                 updates.push(GraphUpdate::NewEdge(edge));
             }
         }
-
-        updates
     }
 
     pub fn clear(&mut self) {
         self.nodes.clear();
         self.edges.clear();
+        self.ip_index.clear();
     }
 
     pub fn get_all_graph_data(&self) -> GraphData {
         let nodes = self.nodes.clone();
         let edges = self.edges.clone();
-        GraphData { nodes, edges }
+        GraphData {
+            nodes,
+            edges,
+            ip_index: HashMap::new(),
+        }
     }
 
-    pub fn update_node_label(&mut self, mac: &str, ip: &str, label: String) -> Option<GraphUpdate> {
+    /// Applique un label à tous les nœuds correspondant à l'endpoint
+    /// `(mac, ip)`. Le matching couvre **toutes** les MAC observées du nœud
+    /// (pas seulement la première, #154) et peut toucher plusieurs nœuds :
+    /// la même (mac, ip) vue sur deux VLAN est deux nœuds, tous étiquetés.
+    /// Une MAC vide matche par IP seule ; une IP vide matche les nœuds L2.
+    pub fn update_node_label(&mut self, mac: &str, ip: &str, label: String) -> Vec<GraphUpdate> {
         let normalized = if label.trim().is_empty() {
             None
         } else {
             Some(label)
         };
 
+        let mut updates = Vec::new();
         for node in self.nodes.values_mut() {
-            if node.mac == mac && node.ip == ip {
-                if node.label != normalized {
-                    node.label = normalized;
-                    return Some(GraphUpdate::NodeUpdated(node.clone()));
-                }
-                return None;
+            if !node_matches_endpoint(node, mac, ip) {
+                continue;
+            }
+            if node.label != normalized {
+                node.label = normalized.clone();
+                updates.push(GraphUpdate::NodeUpdated(node.clone()));
             }
         }
 
-        None
+        updates
     }
 
     /// Réapplique les labels de tous les nœuds via `resolve(mac, ip)`
-    /// (typiquement `FlowMatrix::get_label` et ses replis IP seule / MAC seule).
-    /// Retourne un `NodeUpdated` par nœud effectivement modifié.
+    /// (typiquement `FlowMatrix::get_label` et ses replis IP seule / MAC
+    /// seule). Le résolveur est essayé sur chaque MAC observée du nœud, la
+    /// première réponse gagne (#154) : un label attaché à une MAC secondaire
+    /// n'est plus invisible. Retourne un `NodeUpdated` par nœud modifié.
     pub fn refresh_labels<F>(&mut self, resolve: F) -> Vec<GraphUpdate>
     where
         F: Fn(&str, &str) -> Option<String>,
@@ -584,7 +643,15 @@ impl GraphData {
         let mut updates = Vec::new();
 
         for node in self.nodes.values_mut() {
-            let Some(label) = resolve(&node.mac, &node.ip) else {
+            let resolved = std::iter::once(node.mac.as_str())
+                .chain(
+                    node.macs
+                        .iter()
+                        .filter(|m| **m != node.mac)
+                        .map(String::as_str),
+                )
+                .find_map(|mac| resolve(mac, &node.ip));
+            let Some(label) = resolved else {
                 continue;
             };
 
@@ -602,6 +669,23 @@ impl GraphData {
 
         updates
     }
+}
+
+/// Un nœud correspond-il à l'endpoint `(mac, ip)` d'un label ? Une MAC vide
+/// vaut « n'importe quelle MAC » ; une IP vide ne matche que les nœuds sans
+/// IP (L2). Un couple entièrement vide ne matche rien.
+fn node_matches_endpoint(node: &Node, mac: &str, ip: &str) -> bool {
+    if mac.is_empty() && ip.is_empty() {
+        return false;
+    }
+    let mac_matches =
+        mac.is_empty() || node.mac == mac || node.macs.iter().any(|known| known == mac);
+    let ip_matches = if ip.is_empty() {
+        node.ip.is_empty()
+    } else {
+        node.ip == ip
+    };
+    mac_matches && ip_matches
 }
 
 // ————— helpers —————
@@ -758,6 +842,8 @@ mod graph_update_batch_tests {
             mac: "aa:bb:cc:dd:ee:ff".to_string(),
             macs: vec!["aa:bb:cc:dd:ee:ff".to_string()],
             ip: "10.0.0.1".to_string(),
+            vlan_id: None,
+            duplicate_ip: false,
             label: label.map(str::to_string),
         }
     }
@@ -850,6 +936,8 @@ mod add_packet_flow_tests {
     use super::*;
     use crate::link::ethernet_link_from_text;
     use packet_parser::owned::InternetOwned;
+    use packet_parser::parse::data_link::ethertype::Ethertype;
+    use packet_parser::parse::data_link::vlan_tag::VlanTag;
     use std::net::IpAddr;
 
     /// Flux L3 minimal : IPv4 privé des deux côtés (chemin L3 du graphe).
@@ -872,6 +960,29 @@ mod add_packet_flow_tests {
 
     fn add(graph: &mut GraphData, f: &PacketFlowOwned) -> Vec<GraphUpdate> {
         graph.add_packet_flow(f, None, None, 1, 100, &[])
+    }
+
+    /// Même flux L3, mais dans une trame 802.1Q taguée `vlan`.
+    fn flow_on_vlan(
+        src_mac: &str,
+        src_ip: &str,
+        dst_mac: &str,
+        dst_ip: &str,
+        vlan: u16,
+    ) -> PacketFlowOwned {
+        let mut f = flow(src_mac, src_ip, dst_mac, dst_ip);
+        f.data_link = ethernet_link_from_text(
+            src_mac,
+            dst_mac,
+            "IPv4",
+            Some(VlanTag {
+                id: vlan,
+                pcp: 0,
+                dei: false,
+                inner_ethertype: Ethertype(0x0800),
+            }),
+        );
+        f
     }
 
     fn flow_with_ports(
@@ -1105,6 +1216,328 @@ mod add_packet_flow_tests {
             node.macs.len(),
             MAX_MACS_PER_NODE,
             "la liste des MAC est plafonnée"
+        );
+    }
+
+    /// La même IP sur deux VLAN est deux actifs distincts : deux nœuds, avec
+    /// leur VLAN respectif, tous deux marqués `duplicate_ip` (anomalie
+    /// signalée, jamais fusionnée — #154).
+    #[test]
+    fn same_ip_on_two_vlans_makes_two_flagged_nodes() {
+        let mut graph = GraphData::new();
+        add(
+            &mut graph,
+            &flow_on_vlan(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+                10,
+            ),
+        );
+        let updates = add(
+            &mut graph,
+            &flow_on_vlan(
+                "20:00:00:00:00:0a",
+                "192.168.1.10",
+                "20:00:00:00:00:0b",
+                "192.168.1.20",
+                20,
+            ),
+        );
+
+        assert_eq!(graph.nodes.len(), 4, "deux nœuds par IP, un par VLAN");
+
+        let on_vlan10 = graph.nodes.get("vlan10:192.168.1.10").unwrap();
+        let on_vlan20 = graph.nodes.get("vlan20:192.168.1.10").unwrap();
+        assert_eq!(on_vlan10.vlan_id, Some(10));
+        assert_eq!(on_vlan20.vlan_id, Some(20));
+        assert_ne!(on_vlan10.id, on_vlan20.id, "deux identités distinctes");
+        assert!(on_vlan10.duplicate_ip, "l'anomalie IP dupliquée est levée");
+        assert!(on_vlan20.duplicate_ip);
+        assert_eq!(
+            on_vlan10.macs,
+            vec!["10:00:00:00:00:0a".to_string()],
+            "les MAC ne se mélangent pas entre VLAN"
+        );
+        assert!(
+            updates.iter().any(
+                |u| matches!(u, GraphUpdate::NodeUpdated(n) if n.duplicate_ip
+                    && n.vlan_id == Some(10))
+            ),
+            "le nœud du premier VLAN est re-notifié avec l'anomalie"
+        );
+
+        // Le trafic ne se mélange pas non plus : deux arêtes distinctes.
+        assert_eq!(graph.edges.len(), 2);
+    }
+
+    /// Une trame non taguée et une trame taguée portant la même IP font
+    /// aussi deux nœuds : l'absence de tag est une identité à part entière.
+    #[test]
+    fn untagged_and_tagged_frames_with_same_ip_stay_distinct() {
+        let mut graph = GraphData::new();
+        add(
+            &mut graph,
+            &flow(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+        add(
+            &mut graph,
+            &flow_on_vlan(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+                20,
+            ),
+        );
+
+        let untagged = graph.nodes.get("192.168.1.10").unwrap();
+        let tagged = graph.nodes.get("vlan20:192.168.1.10").unwrap();
+        assert_eq!(untagged.vlan_id, None);
+        assert_eq!(tagged.vlan_id, Some(20));
+        assert!(untagged.duplicate_ip && tagged.duplicate_ip);
+    }
+
+    /// Les ids de nœuds et d'arêtes sont dérivés de l'identité, plus d'un
+    /// compteur global : deux graphes construits séparément (ordre inversé)
+    /// donnent les mêmes ids — snapshots déterministes (#154).
+    #[test]
+    fn node_and_edge_ids_are_stable_across_graphs_and_insertion_order() {
+        let a_to_b = flow(
+            "10:00:00:00:00:0a",
+            "192.168.1.10",
+            "10:00:00:00:00:0b",
+            "192.168.1.20",
+        );
+        let c_to_d = flow_on_vlan(
+            "10:00:00:00:00:0c",
+            "192.168.1.30",
+            "10:00:00:00:00:0d",
+            "192.168.1.40",
+            30,
+        );
+
+        let mut first = GraphData::new();
+        add(&mut first, &a_to_b);
+        add(&mut first, &c_to_d);
+
+        let mut second = GraphData::new();
+        add(&mut second, &c_to_d);
+        add(&mut second, &a_to_b);
+
+        for key in first.nodes.keys() {
+            assert_eq!(
+                first.nodes[key].id, second.nodes[key].id,
+                "id de nœud instable pour {key}"
+            );
+        }
+        let mut first_edge_ids: Vec<_> = first.edges.values().map(|e| e.id.clone()).collect();
+        let mut second_edge_ids: Vec<_> = second.edges.values().map(|e| e.id.clone()).collect();
+        first_edge_ids.sort();
+        second_edge_ids.sort();
+        assert_eq!(first_edge_ids, second_edge_ids, "ids d'arêtes instables");
+    }
+
+    /// Changement de MAC (remplacement de carte, usurpation) : le nœud garde
+    /// son identité (clé (vlan, ip), id inchangé), la nouvelle MAC s'ajoute
+    /// aux MAC observées et l'anomalie multi-MAC est visible.
+    #[test]
+    fn mac_change_keeps_node_identity() {
+        let mut graph = GraphData::new();
+        add(
+            &mut graph,
+            &flow(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+        let id_before = graph.nodes.get("192.168.1.10").unwrap().id.clone();
+
+        add(
+            &mut graph,
+            &flow(
+                "de:ad:be:ef:00:01",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+
+        let node = graph.nodes.get("192.168.1.10").unwrap();
+        assert_eq!(
+            node.id, id_before,
+            "l'identité du nœud survit au changement"
+        );
+        assert_eq!(node.macs.len(), 2, "les deux MAC restent observées");
+        assert!(!node.duplicate_ip, "pas de doublon d'IP inter-VLAN ici");
+    }
+
+    /// Un label posé via une MAC secondaire (pas la première observée)
+    /// atteint le nœud : le matching couvre toutes les MAC observées (#154).
+    #[test]
+    fn update_node_label_matches_all_observed_macs() {
+        let mut graph = GraphData::new();
+        add(
+            &mut graph,
+            &flow(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+        add(
+            &mut graph,
+            &flow(
+                "de:ad:be:ef:00:01",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+
+        let updates =
+            graph.update_node_label("de:ad:be:ef:00:01", "192.168.1.10", "Automate 1".into());
+        assert_eq!(updates.len(), 1, "le nœud est trouvé via sa MAC secondaire");
+        assert_eq!(
+            graph.nodes.get("192.168.1.10").unwrap().label.as_deref(),
+            Some("Automate 1")
+        );
+    }
+
+    /// La même (mac, ip) vue sur deux VLAN : les deux nœuds reçoivent le
+    /// label (c'est le même équipement physique vu sur deux segments —
+    /// l'étiquette humaine s'applique aux deux).
+    #[test]
+    fn update_node_label_reaches_all_vlan_siblings() {
+        let mut graph = GraphData::new();
+        for vlan in [10, 20] {
+            add(
+                &mut graph,
+                &flow_on_vlan(
+                    "10:00:00:00:00:0a",
+                    "192.168.1.10",
+                    "10:00:00:00:00:0b",
+                    "192.168.1.20",
+                    vlan,
+                ),
+            );
+        }
+
+        let updates =
+            graph.update_node_label("10:00:00:00:00:0a", "192.168.1.10", "Poste SCADA".into());
+        assert_eq!(updates.len(), 2, "les deux nœuds VLAN sont étiquetés");
+
+        // Ré-application du même label : aucune notification superflue.
+        let updates =
+            graph.update_node_label("10:00:00:00:00:0a", "192.168.1.10", "Poste SCADA".into());
+        assert!(updates.is_empty());
+    }
+
+    /// `refresh_labels` essaie chaque MAC observée du nœud : un label stocké
+    /// pour la MAC secondaire est retrouvé (#154).
+    #[test]
+    fn refresh_labels_resolves_via_secondary_mac() {
+        let mut graph = GraphData::new();
+        add(
+            &mut graph,
+            &flow(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+        add(
+            &mut graph,
+            &flow(
+                "de:ad:be:ef:00:01",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+            ),
+        );
+
+        let updates = graph.refresh_labels(|mac, ip| {
+            (mac == "de:ad:be:ef:00:01" && ip == "192.168.1.10").then(|| "Automate 2".to_string())
+        });
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            graph.nodes.get("192.168.1.10").unwrap().label.as_deref(),
+            Some("Automate 2")
+        );
+    }
+
+    /// Le repli L2 est lui aussi VLAN-aware : la même MAC taguée sur deux
+    /// VLAN fait deux nœuds.
+    #[test]
+    fn l2_fallback_separates_vlans() {
+        let mut graph = GraphData::new();
+        for vlan in [10, 20] {
+            let mut f = flow_on_vlan(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+                vlan,
+            );
+            f.internet = None; // force le repli L2
+            add(&mut graph, &f);
+        }
+
+        assert_eq!(graph.nodes.len(), 4);
+        assert!(graph.nodes.contains_key("vlan10:mac:10:00:00:00:00:0a"));
+        assert!(graph.nodes.contains_key("vlan20:mac:10:00:00:00:00:0a"));
+        assert_eq!(
+            graph
+                .nodes
+                .get("vlan10:mac:10:00:00:00:00:0a")
+                .unwrap()
+                .vlan_id,
+            Some(10)
+        );
+    }
+
+    /// `clear` remet aussi l'index IP à zéro : après reset, une IP revue
+    /// seule n'est pas marquée dupliquée.
+    #[test]
+    fn clear_resets_duplicate_ip_tracking() {
+        let mut graph = GraphData::new();
+        for vlan in [10, 20] {
+            add(
+                &mut graph,
+                &flow_on_vlan(
+                    "10:00:00:00:00:0a",
+                    "192.168.1.10",
+                    "10:00:00:00:00:0b",
+                    "192.168.1.20",
+                    vlan,
+                ),
+            );
+        }
+        graph.clear();
+
+        add(
+            &mut graph,
+            &flow_on_vlan(
+                "10:00:00:00:00:0a",
+                "192.168.1.10",
+                "10:00:00:00:00:0b",
+                "192.168.1.20",
+                10,
+            ),
+        );
+        assert!(
+            !graph.nodes.get("vlan10:192.168.1.10").unwrap().duplicate_ip,
+            "plus de doublon après clear"
         );
     }
 

--- a/sonar-rust/crates/sonar-flows-core/src/packet.rs
+++ b/sonar-rust/crates/sonar-flows-core/src/packet.rs
@@ -16,7 +16,7 @@ use crate::link::LinkView;
 /// `DefaultHasher`, dont la stabilité n'est pas garantie entre versions de
 /// Rust, deux builds différents produisent les mêmes `encap_id` — les
 /// matrices exportées restent joignables entre elles (#148).
-fn fnv1a(bytes: &[u8]) -> u64 {
+pub(crate) fn fnv1a(bytes: &[u8]) -> u64 {
     const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
     bytes.iter().fold(OFFSET, |hash, byte| {


### PR DESCRIPTION
## Tranche 1 du cadrage #154 — sonar-flows-core 0.5.0

Réf. `project_management/cadrage_identite_actif_154.md` (arbitrages du 04/08).

### Ce qui change
- **Clé de nœud `(vlan, ip)`** (`l3_node_key`), repli L2 `(vlan, mac)` : la même IP sur deux VLAN est deux actifs distincts, plus jamais fusionnés implicitement. Hors trame taguée, la clé reste l'IP nue (continuité des relevés existants).
- **Ids stables** : nœuds et arêtes tirent leur id d'un hash FNV-1a de leur clé d'identité (le même hachage, stable entre builds, que `encap_id`) — les compteurs globaux disparaissent. Même relevé rouvert ⇒ mêmes ids (prérequis corrélation d'actifs #164, snapshots déterministes).
- **`Node.vlan_id`** exposé (contrat TS à régénérer au re-vendoring) et **`Node.duplicate_ip`** : une IP portée par plusieurs nœuds (VLAN différents) est signalée via un index IP→nœuds, jamais fusionnée.
- **Labels multi-MAC** : `update_node_label` matche toutes les MAC observées du nœud et étiquette tous les nœuds de l'endpoint (retour `Vec<GraphUpdate>`) ; `refresh_labels` essaie le résolveur sur chaque MAC observée. Le palier `(vlan, mac, ip)` exact part en tranche 2 (il exige le VLAN dans labels.csv, hors périmètre tranche 1).
- **sonar-flows-cli** : le départage des égalités de trafic de l'export Graphviz tranche sur l'identité lisible (IP/MAC), plus sur l'id devenu opaque.

### Ce qui ne change pas
Ni la clé de la matrice, ni `encap_id`, ni les CSV (SFMS et labels) : `.sonar` reste schéma v1, le graphe étant reconstruit depuis la matrice qui porte déjà le VLAN.

### Tests
11 tests ajoutés (VLAN distincts, IP dupliquées avec anomalie, non-tagué vs tagué, stabilité des ids à l'ordre d'insertion, changement de MAC, labels via MAC secondaire, labels multi-VLAN, repli L2 VLAN-aware, reset de l'index). Workspace : 72 core + 8 CLI verts, clippy/fmt propres.

### Après merge
1. Tag `crates-v0.5.0` → `publish-crates.yml` publie sur crates.io
2. Re-vendor dans `src-tauri` (`=0.5.0`) + cargo vet
3. PR desktop : adaptation `update_node_label` (labels/commands.rs), régénération du contrat TS, affichage VLAN + badge `duplicate_ip` dans le panneau nœud

🤖 Generated with [Claude Code](https://claude.com/claude-code)
