### PR TITLE
feat(154): contexte de relevé dans le préambule SFMS — sonar-flows-core 0.6.0

### DIFF
--- a/project_management/cadrage_identite_actif_154.md
+++ b/project_management/cadrage_identite_actif_154.md
@@ -124,6 +124,31 @@ fuzz), publié sur crates.io par `.github/workflows/publish-crates.yml`.
 Cycle tranche 1 : PR sur `sonar-rust` (0.5.0) → publication → re-vendor
 `src-tauri` → vet, comme pour packet_parser 9 (PR #183).
 
+### Tranche 2, étape 1 — 04/08/2026 (sonar-flows-core 0.6.0)
+
+Contexte de relevé au niveau du **préambule SFMS** (le niveau « par
+relevé » de la tranche 2) :
+
+- `SurveyContext { site, sensor, interface }`, tous optionnels, avec
+  normalisation des saisies vides/blanches. **Clés du format en anglais**
+  (`site=`, `sensor=`, `interface=`) par cohérence avec les en-têtes de
+  colonnes, déjà anglais — « capteur » reste le terme d'interface.
+- `SFMS_VERSION` passe à **2**. Les valeurs libres (espaces, accents,
+  `=`, `%`) sont percent-encodées : le préambule reste un
+  `clé=valeur` non ambigu. Un échappement corrompu est une erreur, pas
+  une valeur devinée.
+- Lecture v1 inchangée (contexte vide) ; un fichier v2 lu par un SONAR
+  antérieur reste valide, ses clés inconnues étant déjà tolérées.
+- `FlowMatrix.context` + `write_rows_to_csv_with_context` ;
+  `write_rows_to_csv`/`format_preamble` conservent leur signature et
+  écrivent sans contexte.
+- Fixture de référence `ultimate_ethernet_sample.csv` régénérée en v2 ;
+  les autres fixtures restent en v1 et couvrent la lecture ascendante.
+
+Restent pour la tranche 2 : le dialogue de qualification au stop/save
+côté desktop, le `manifest.json` v2 du `.sonar`, et la généralisation
+d'`origin` en contexte par flux (fusion multi-sites).
+
 ### Tranche 1 implémentée — 04/08/2026 (sonar-flows-core 0.5.0)
 
 - Clé de nœud `(vlan, ip)` (`l3_node_key`), repli L2 `(vlan, mac)` ;

--- a/sonar-rust/Cargo.lock
+++ b/sonar-rust/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sonar-flows-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "csv",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "sonar-flows-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "csv",

--- a/sonar-rust/Cargo.toml
+++ b/sonar-rust/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/Sonar-team/Sonar_desktop_app"
 rust-version = "1.97.1"
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies]
 chrono = "0.4.45"
@@ -22,7 +22,7 @@ log = "0.4.33"
 packet_parser = "9.0.0"
 pcap = "2.4.0"
 serde = { version = "1", features = ["derive"] }
-sonar-flows-core = { path = "crates/sonar-flows-core", version = "0.5.0" }
+sonar-flows-core = { path = "crates/sonar-flows-core", version = "0.6.0" }
 thiserror = "2.0.19"
 
 # Même politique que src-tauri : pas de panic évitable en code de prod.

--- a/sonar-rust/crates/sonar-flows-core/src/csv.rs
+++ b/sonar-rust/crates/sonar-flows-core/src/csv.rs
@@ -278,7 +278,7 @@ mod tests {
             .next()
             .map(str::to_string)
             .expect("fichier non vide");
-        assert_eq!(first_line, "#SFMS version=1 dlt=ETHERNET");
+        assert_eq!(first_line, "#SFMS version=2 dlt=ETHERNET");
 
         let reimported = merge_matrix_files(&[out]).expect("réimport avec préambule");
         assert_eq!(reimported.row_count(), matrix.row_count());

--- a/sonar-rust/crates/sonar-flows-core/src/matrix.rs
+++ b/sonar-rust/crates/sonar-flows-core/src/matrix.rs
@@ -149,6 +149,11 @@ pub struct FlowMatrix {
     // `bind_link_type`. Un relevé = un réseau = un DLT (arbitrage 14/07/2026) :
     // toute source d'un autre DLT est refusée. `None` = matrice vierge.
     pub link_type: Option<packet_parser::LinkType>,
+    // Contexte du relevé (site, capteur, interface), déclaré par l'opérateur
+    // à l'arrêt de la capture ou à l'enregistrement (#154, tranche 2). Écrit
+    // dans le préambule #SFMS à l'export ; volontairement hors de la clé des
+    // flux — le même paquet peut être vu par plusieurs capteurs.
+    pub context: crate::sfms::SurveyContext,
 }
 
 impl Default for FlowMatrix {
@@ -164,6 +169,7 @@ impl FlowMatrix {
             label: HashMap::new(),
             origins: HashMap::new(),
             link_type: None,
+            context: crate::sfms::SurveyContext::default(),
         }
     }
 
@@ -457,7 +463,12 @@ impl FlowMatrix {
     /// Exporte la matrice vers un fichier CSV (écriture atomique), préambule
     /// `#SFMS` en tête (version du format, DLT du relevé).
     pub fn export_to_csv(&self, path: String) -> std::io::Result<()> {
-        Self::write_rows_to_csv(&self.to_flat_vec(), self.link_type, &path)
+        Self::write_rows_to_csv_with_context(
+            &self.to_flat_vec(),
+            self.link_type,
+            &self.context,
+            &path,
+        )
     }
 
     /// Écrit des lignes de matrice (snapshot de [`Self::to_flat_vec`]) vers
@@ -469,7 +480,24 @@ impl FlowMatrix {
         link_type: Option<packet_parser::LinkType>,
         path: &str,
     ) -> std::io::Result<()> {
-        write_csv_atomically(path, Some(crate::sfms::format_preamble(link_type)), |wtr| {
+        Self::write_rows_to_csv_with_context(
+            rows,
+            link_type,
+            &crate::sfms::SurveyContext::default(),
+            path,
+        )
+    }
+
+    /// Variante portant le contexte du relevé (site, capteur, interface) dans
+    /// le préambule `#SFMS` (#154, tranche 2).
+    pub fn write_rows_to_csv_with_context(
+        rows: &[FlowMatrixRow],
+        link_type: Option<packet_parser::LinkType>,
+        context: &crate::sfms::SurveyContext,
+        path: &str,
+    ) -> std::io::Result<()> {
+        let preamble = crate::sfms::format_preamble_with_context(link_type, context);
+        write_csv_atomically(path, Some(preamble), |wtr| {
             for row in rows {
                 wtr.serialize(row)?;
             }

--- a/sonar-rust/crates/sonar-flows-core/src/sfms.rs
+++ b/sonar-rust/crates/sonar-flows-core/src/sfms.rs
@@ -15,11 +15,49 @@ use packet_parser::LinkType;
 
 use crate::{Result, SonarCoreError};
 
-/// Version du format de préambule écrite par cette version de SONAR.
-pub const SFMS_VERSION: &str = "1";
+/// Version du format de préambule écrite par cette version de SONAR. La
+/// version 2 ajoute le contexte de relevé ([`SurveyContext`]) ; la lecture
+/// des fichiers v1 est inchangée.
+pub const SFMS_VERSION: &str = "2";
 
 /// Marqueur de la ligne de préambule, en tête de fichier.
 pub const PREAMBLE_MARKER: &str = "#SFMS";
+
+/// Contexte d'un relevé : où et par quoi il a été capté (#154, tranche 2).
+///
+/// Ces informations n'existent pas dans le paquet : elles sont déclarées par
+/// l'opérateur au moment de l'arrêt de la capture ou de l'enregistrement
+/// (arbitrage du 04/08/2026, à la manière de Wireshark). Elles décrivent le
+/// **relevé entier** et restent volontairement hors de la clé d'identité des
+/// flux et des nœuds : le même paquet peut être vu par plusieurs capteurs, et
+/// mettre le capteur dans la clé empêcherait de reconnaître ce recouvrement.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SurveyContext {
+    /// Site d'audit (« Usine Nord », « Poste 63 kV »…).
+    pub site: Option<String>,
+    /// Capteur ayant réalisé le relevé (nom de la sonde ou de la machine).
+    pub sensor: Option<String>,
+    /// Interface d'écoute (`eth0`…), connue de SONAR en capture live.
+    pub interface: Option<String>,
+}
+
+impl SurveyContext {
+    /// Aucun champ renseigné : le préambule n'émet alors aucune clé de
+    /// contexte (un export sans contexte reste identique à un export v1 à la
+    /// version près).
+    pub fn is_empty(&self) -> bool {
+        self.site.is_none() && self.sensor.is_none() && self.interface.is_none()
+    }
+
+    /// Normalise une saisie utilisateur : une valeur vide ou uniquement
+    /// blanche vaut « non renseigné », les blancs de bord sont retirés.
+    pub fn normalized_field(value: Option<&str>) -> Option<String> {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    }
+}
 
 /// Métadonnées lues dans une ligne de préambule `#SFMS`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +67,49 @@ pub struct SfmsPreamble {
     /// Type de liaison du relevé (`dlt=`), absent si le fichier ne le
     /// déclare pas.
     pub link_type: Option<LinkType>,
+    /// Contexte du relevé (v2). Vide pour un fichier v1.
+    pub context: SurveyContext,
+}
+
+/// Encode une valeur libre pour tenir dans un champ `clé=valeur` séparé par
+/// des espaces : tout ce qui n'est pas alphanumérique ASCII ou `-._~` passe
+/// en `%XX` (UTF-8 octet par octet). Un nom de site avec espaces, accents ou
+/// `=` traverse ainsi le préambule sans le rendre ambigu.
+fn encode_value(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(*byte as char)
+            }
+            other => encoded.push_str(&format!("%{other:02X}")),
+        }
+    }
+    encoded
+}
+
+/// Inverse de [`encode_value`]. Une séquence `%` invalide est une erreur :
+/// une métadonnée illisible ne doit jamais être devinée.
+fn decode_value(value: &str) -> std::result::Result<String, String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let hex = value
+                .get(index + 1..index + 3)
+                .ok_or_else(|| format!("échappement incomplet dans « {value} »"))?;
+            decoded.push(
+                u8::from_str_radix(hex, 16)
+                    .map_err(|_| format!("échappement invalide « %{hex} » dans « {value} »"))?,
+            );
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded).map_err(|_| format!("valeur non UTF-8 dans « {value} »"))
 }
 
 /// Nom canonique d'un type de liaison pour le préambule et les messages
@@ -58,15 +139,33 @@ pub fn link_type_from_text(text: &str) -> Option<LinkType> {
     }
 }
 
-/// Ligne de préambule écrite en tête d'un export de matrice.
+/// Ligne de préambule écrite en tête d'un export de matrice, sans contexte
+/// de relevé (capture non qualifiée, exports internes).
 pub fn format_preamble(link_type: Option<LinkType>) -> String {
-    match link_type {
-        Some(link_type) => format!(
-            "{PREAMBLE_MARKER} version={SFMS_VERSION} dlt={}",
-            link_type_name(link_type)
-        ),
-        None => format!("{PREAMBLE_MARKER} version={SFMS_VERSION}"),
+    format_preamble_with_context(link_type, &SurveyContext::default())
+}
+
+/// Ligne de préambule portant le contexte du relevé (#154). Les champs non
+/// renseignés n'émettent aucune clé : un export sans contexte reste
+/// exactement l'ancienne ligne, à la version près.
+pub fn format_preamble_with_context(
+    link_type: Option<LinkType>,
+    context: &SurveyContext,
+) -> String {
+    let mut line = format!("{PREAMBLE_MARKER} version={SFMS_VERSION}");
+    if let Some(link_type) = link_type {
+        line.push_str(&format!(" dlt={}", link_type_name(link_type)));
     }
+    for (key, value) in [
+        ("site", context.site.as_ref()),
+        ("sensor", context.sensor.as_ref()),
+        ("interface", context.interface.as_ref()),
+    ] {
+        if let Some(value) = value {
+            line.push_str(&format!(" {key}={}", encode_value(value)));
+        }
+    }
+    line
 }
 
 /// Parse une ligne de préambule. `Ok(None)` si la ligne n'en est pas une
@@ -81,6 +180,7 @@ pub fn parse_preamble(line: &str) -> std::result::Result<Option<SfmsPreamble>, S
 
     let mut version: Option<String> = None;
     let mut link_type: Option<LinkType> = None;
+    let mut context = SurveyContext::default();
     for field in fields.split_whitespace() {
         let Some((key, value)) = field.split_once('=') else {
             return Err(format!("champ de préambule invalide : « {field} »"));
@@ -92,6 +192,9 @@ pub fn parse_preamble(line: &str) -> std::result::Result<Option<SfmsPreamble>, S
                     format!("type de liaison illisible dans le préambule : « {value} »")
                 })?);
             }
+            "site" => context.site = Some(decode_value(value)?),
+            "sensor" => context.sensor = Some(decode_value(value)?),
+            "interface" => context.interface = Some(decode_value(value)?),
             // Clés inconnues tolérées : un fichier plus récent reste lisible.
             _ => {}
         }
@@ -100,6 +203,7 @@ pub fn parse_preamble(line: &str) -> std::result::Result<Option<SfmsPreamble>, S
     Ok(Some(SfmsPreamble {
         version: version.unwrap_or_else(|| SFMS_VERSION.to_string()),
         link_type,
+        context,
     }))
 }
 
@@ -169,5 +273,72 @@ mod tests {
 
         assert!(parse_preamble("#SFMS version=1 dlt=N_IMPORTE_QUOI").is_err());
         assert!(parse_preamble("#SFMS champ_sans_valeur").is_err());
+    }
+
+    /// Le contexte de relevé traverse le préambule sans perte, y compris des
+    /// valeurs libres contenant espaces, accents, `=` et `%` — un nom de site
+    /// est saisi par un humain, pas contraint (#154).
+    #[test]
+    fn survey_context_round_trips_free_text_values() {
+        let context = SurveyContext {
+            site: Some("Usine Nord — atelier 3".to_string()),
+            sensor: Some("sonde=A 100%".to_string()),
+            interface: Some("eth0".to_string()),
+        };
+
+        let line = format_preamble_with_context(Some(LinkType::ETHERNET), &context);
+        assert!(
+            !line.contains("Usine Nord"),
+            "les espaces doivent être échappés : {line}"
+        );
+
+        let parsed = parse_preamble(&line)
+            .expect("préambule écrit par nous")
+            .expect("ligne de préambule");
+        assert_eq!(parsed.context, context, "aller-retour exact");
+        assert_eq!(parsed.link_type, Some(LinkType::ETHERNET));
+        assert_eq!(parsed.version, "2");
+    }
+
+    /// Sans contexte, la ligne reste celle d'avant (à la version près) : un
+    /// export non qualifié n'invente aucune métadonnée.
+    #[test]
+    fn a_preamble_without_context_emits_no_context_key() {
+        let line = format_preamble(Some(LinkType::ETHERNET));
+        assert_eq!(line, "#SFMS version=2 dlt=ETHERNET");
+
+        let parsed = parse_preamble(&line).expect("valide").expect("préambule");
+        assert!(parsed.context.is_empty());
+    }
+
+    /// Un relevé v1 se lit inchangé, avec un contexte simplement vide.
+    #[test]
+    fn a_v1_file_reads_with_an_empty_context() {
+        let parsed = parse_preamble("#SFMS version=1 dlt=LINUX_SLL")
+            .expect("valide")
+            .expect("préambule");
+        assert_eq!(parsed.version, "1");
+        assert_eq!(parsed.link_type, Some(LinkType::LINUX_SLL));
+        assert!(parsed.context.is_empty(), "aucun contexte inventé");
+    }
+
+    /// Un échappement corrompu est refusé plutôt que deviné.
+    #[test]
+    fn a_broken_escape_is_refused() {
+        assert!(parse_preamble("#SFMS version=2 site=Usine%").is_err());
+        assert!(parse_preamble("#SFMS version=2 site=Usine%ZZ").is_err());
+    }
+
+    /// Les saisies vides ou blanches valent « non renseigné » : le préambule
+    /// ne se remplit pas de champs vides.
+    #[test]
+    fn blank_user_input_is_normalized_to_absent() {
+        assert_eq!(SurveyContext::normalized_field(Some("   ")), None);
+        assert_eq!(SurveyContext::normalized_field(Some("")), None);
+        assert_eq!(SurveyContext::normalized_field(None), None);
+        assert_eq!(
+            SurveyContext::normalized_field(Some("  Poste 63 kV  ")),
+            Some("Poste 63 kV".to_string())
+        );
     }
 }

--- a/src-tauri/test_files/pcaps/import/ultimate_ethernet_sample/ultimate_ethernet_sample.csv
+++ b/src-tauri/test_files/pcaps/import/ultimate_ethernet_sample/ultimate_ethernet_sample.csv
@@ -1,4 +1,4 @@
-#SFMS version=1 dlt=ETHERNET
+#SFMS version=2 dlt=ETHERNET
 mac_source,mac_destination,vlan_id,protocol_data_link,ip_source,ip_source_type,label_source,ip_destination,ip_destination_type,label_destination,port_source,port_destination,protocol_transport,application_protocol,count,total_bytes,last_seen,encap_id,origin
 00:00:00:00:00:00,00:00:00:00:00:00,,IPv4,127.0.0.1,Loopback,,127.0.0.1,Loopback,,5246,34751,UDP,Unknown,1,167,2014-02-10 20:06:58.957782 UTC,,
 00:00:00:00:00:00,00:00:00:00:00:00,,IPv4,127.0.0.1,Loopback,,127.0.0.1,Loopback,,5247,35981,UDP,Unknown,1,72,2014-02-10 20:06:59.066632 UTC,,


### PR DESCRIPTION
Première étape de la **tranche 2** de #154, côté crate : le relevé porte où et par quoi il a été capté.

Ces informations n'existent pas dans le paquet — elles sont déclarées par l'opérateur, et l'arbitrage du 04/08 place cette saisie **au moment de l'arrêt ou de l'enregistrement, à la manière de Wireshark** (pas de configuration a priori). Cette PR pose le format ; le dialogue de qualification suit côté desktop.

## Ce que ça ajoute

- `SurveyContext { site, sensor, interface }`, tous optionnels, avec normalisation des saisies vides ou blanches en « non renseigné ».
- `SFMS_VERSION` passe à **2**. Les valeurs sont du texte libre saisi par un humain : elles sont percent-encodées, donc un site nommé `Usine Nord — atelier 3` ou un capteur `sonde=A 100%` traverse le préambule sans le rendre ambigu. Un échappement corrompu est une **erreur**, jamais une valeur devinée.
- `FlowMatrix.context` et `write_rows_to_csv_with_context`. `format_preamble`/`write_rows_to_csv` gardent leur signature et écrivent sans contexte : aucun appelant existant ne change de comportement.

## Compatibilité

- **Lecture v1 inchangée** : un ancien relevé se lit avec un contexte simplement vide, aucune métadonnée inventée.
- **v2 lisible par un SONAR antérieur** : les clés inconnues étaient déjà tolérées par le parseur, seule la version diffère.
- Sans contexte, la ligne écrite est exactement l'ancienne à la version près.

Le contexte reste **hors de la clé** des flux et des nœuds, conformément à l'arbitrage : le même paquet peut être vu par plusieurs capteurs, et le mettre dans la clé empêcherait de reconnaître ce recouvrement.

## Vérification

Workspace vert (77 tests crate + 8 CLI + 6 pcap), clippy et fmt propres. 6 tests ajoutés : aller-retour de texte libre, préambule sans contexte, lecture v1, échappement corrompu, normalisation des saisies blanches.

La fixture de référence `ultimate_ethernet_sample.csv` (comparée octet par octet) est régénérée en v2 ; les autres fixtures restent en v1 et couvrent la lecture ascendante.

## Après merge

Tag `crates-v0.6.0` → publication → re-vendor. Puis, côté desktop : dialogue de qualification au stop/save, `manifest.json` v2 du `.sonar`, et généralisation d'`origin` en contexte par flux pour la fusion multi-sites.

Réf. #154 (tranche 2, étape 1 — ne ferme pas l'issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)